### PR TITLE
fix: join the strings in isAzureAuthInstalled

### DIFF
--- a/packages/ado-npm-auth/src/azureauth/is-azureauth-installed.ts
+++ b/packages/ado-npm-auth/src/azureauth/is-azureauth-installed.ts
@@ -9,7 +9,7 @@ let memo: boolean | undefined = undefined;
  */
 export const isAzureAuthInstalled = async (): Promise<boolean> => {
   if (memo === undefined) {
-    const command = `${azureAuthCommand()} --version`;
+    const command = `${azureAuthCommand().join(" ")} --version`;
 
     try {
       const result = await exec(command);


### PR DESCRIPTION
Since `azureAuthCommand()` returns `string[]`, when using it, when adding the `--version` flag, we just concati t with `,` and therefor it always falls back to the catch.