### PR TITLE
Fail faster in `checkTokens` 

### DIFF
--- a/packages/ado-npm-auth/src/npmrc/check-tokens.ts
+++ b/packages/ado-npm-auth/src/npmrc/check-tokens.ts
@@ -9,7 +9,7 @@ import { getUserNPMRC } from "./npmrc.js";
  * @param { boolean } [options.silent]
  * @param { Array<NpmrcOrg> } [options.feeds]
  */
-export const checkTokens = async function ({ feeds }: { feeds: NpmrcOrg[] }) {
+export const checkTokens = async function ({ feeds }: { feeds: NpmrcOrg[] }): Promise<boolean> {
   const userNpmRc = getUserNPMRC();
   
   const feedsWithPat = await getUserPat({ npmrc: userNpmRc, feeds });
@@ -17,7 +17,7 @@ export const checkTokens = async function ({ feeds }: { feeds: NpmrcOrg[] }) {
   const missingPats = feedsWithPat.filter((item) => !item.pat);
 
   if (missingPats.length) {
-    return false
+    return false;
   }
 
   try {
@@ -26,7 +26,7 @@ export const checkTokens = async function ({ feeds }: { feeds: NpmrcOrg[] }) {
         password: feed.pat ?? "",
         organization: feed.organization,
       })
-    ))
+    ));
     return true;
   } catch (e) {
     return false;

--- a/packages/ado-npm-auth/src/npmrc/check-tokens.ts
+++ b/packages/ado-npm-auth/src/npmrc/check-tokens.ts
@@ -21,17 +21,14 @@ export const checkTokens = async function ({ feeds }: { feeds: NpmrcOrg[] }) {
   }
 
   try {
-    // check each feed for validity
-    for (const feed of feedsWithPat) {
-      await makeADORequest({
-        password: feed.pat || "",
+    await Promise.all(feedsWithPat.map(feed => 
+      makeADORequest({
+        password: feed.pat ?? "",
         organization: feed.organization,
-      });
-    }
-
+      })
+    ))
+    return true;
   } catch (e) {
     return false;
   }
-
-  return true;
 };


### PR DESCRIPTION
Currently the code to check tokens will return `false` if any of the tokens we detect fail the network request.

But we are still doing sequential network calls to check that. 

This PR goes full fail fast via `Promise.all` and returns false if we reject

Is it faster? For most people, prolly not  `¯\_(ツ)_/¯` but if a user has several tokens (like I do) but only the last of 10 is bad, it should give us a faster result.