### PR TITLE
Support discovering `.npmrc` location when repo is managed by Rush

### DIFF
--- a/packages/ado-npm-auth/README.md
+++ b/packages/ado-npm-auth/README.md
@@ -12,6 +12,12 @@ You can run the binary `"ado-npm-auth"` via `yarn ado-npm-auth` or `npm exec ado
 
 It will then shell out to the `azureauth` package on [npm](https://www.npmjs.com/package/azureauth), retrieve a token, and update your `~/.npmrc`.
 
+## Project level `.npmrc` Resolution
+
+We first check your git repo's root folder for a `.npmrc` file. 
+
+If that file does not exist, we will then check if your project is using [Rush](https://github.com/microsoft/rushstack), and attempt to discover the default rush path of `common/config/rush/.npmrc`.
+
 ## Beware the chicken and egg problem
 
 You may need to set the registry to the public NPM feed when running `npm exec` or `npx`. 

--- a/packages/ado-npm-auth/src/npmrc/get-repo-npmrc-ado-orgs.ts
+++ b/packages/ado-npm-auth/src/npmrc/get-repo-npmrc-ado-orgs.ts
@@ -11,7 +11,7 @@ export type NpmrcOrg = {
 };
 
 /**
- * Retrieves the path to the default npmrc file created by Rush init from the rush.json configuration file, if available.
+ * If rush.json is present in workspace root, retrieves the path to the default npmrc file created by Rush init
  *
  * @param {string} workspaceRoot - The root directory of the workspace where rush.json should be located.
  * @returns {Promise<string|null>} - The full path to the Rush-managed npmrc file if found, or null if rush.json is not accessible or does not define an npmrc path.

--- a/packages/ado-npm-auth/src/npmrc/get-repo-npmrc-ado-orgs.ts
+++ b/packages/ado-npm-auth/src/npmrc/get-repo-npmrc-ado-orgs.ts
@@ -1,13 +1,67 @@
 import Config from "@npmcli/config";
 import { getWorkspaceRoot } from "workspace-tools";
 import { join } from "node:path";
-import fs from "node:fs/promises"
+import fs from "node:fs/promises";
 import { getOrganizationFromFeedUrl } from "../utils/get-organization-from-feed-url.js";
 
 export type NpmrcOrg = {
   feed: string;
   organization: string;
   pat?: string;
+};
+
+/**
+ * Retrieves the path to the default npmrc file created by Rush init from the rush.json configuration file, if available.
+ *
+ * @param {string} workspaceRoot - The root directory of the workspace where rush.json should be located.
+ * @returns {Promise<string|null>} - The full path to the Rush-managed npmrc file if found, or null if rush.json is not accessible or does not define an npmrc path.
+ */
+const getRushNpmrcPath = async (
+  workspaceRoot: string,
+): Promise<string | null> => {
+  const rushJsonPath = join(workspaceRoot, "rush.json");
+  try {
+    await fs.access(rushJsonPath);
+    // Check the default Rush .npmrc path
+    return join(workspaceRoot, "common/config/rush/.npmrc");
+  } catch (error) {
+    return null;
+  }
+};
+
+/**
+ * Resolves the path to the .npmrc file for the given workspace. It first checks for an .npmrc file
+ * at the workspace root and if not found, it then checks alternative locations
+ *
+ * @param {string} workspaceRoot - The root directory of the workspace.
+ * @returns {Promise<string>} - The path to the .npmrc file if found.
+ * @throws {Error} - Throws an error if no .npmrc file is found in any of the expected locations.
+ */
+const resolveNpmrcPath = async (workspaceRoot: string): Promise<string> => {
+  // First check for .npmrc at the root directory
+  const rootNpmrcPath = join(workspaceRoot, ".npmrc");
+  try {
+    await fs.access(rootNpmrcPath);
+    return rootNpmrcPath;
+  } catch (error) {
+    console.log(
+      ".npmrc not found at the root. Checking for Rush-managed .npmrc...",
+    );
+  }
+
+  // If not found, check for a Rush-managed .npmrc
+  const rushNpmrcPath = await getRushNpmrcPath(workspaceRoot);
+  if (rushNpmrcPath) {
+    try {
+      await fs.access(rushNpmrcPath);
+      return rushNpmrcPath;
+    } catch (error) {
+      console.log("Rush-managed .npmrc also not found.");
+    }
+  }
+
+  // If no .npmrc file is found in any expected locations
+  throw new Error("No .npmrc file found");
 };
 
 /**
@@ -20,7 +74,7 @@ export const getRepoNpmrcAdoOrganizations = async (): Promise<
 > => {
   const workspaceRoot = getWorkspaceRoot(process.cwd()) || "";
   let config!: Config;
-  const npmrcPath = join(workspaceRoot, ".npmrc")
+  const npmrcPath = await resolveNpmrcPath(workspaceRoot);
 
   try {
     await fs.access(npmrcPath)
@@ -46,7 +100,7 @@ export const getRepoNpmrcAdoOrganizations = async (): Promise<
   // @npmcli/config does not have a normal way to display all keys
   // so we use this ugly access instead
   const projectNpmrcKeys = Object.keys(
-    (config.data?.get("project") || {})["data"] || {}
+    (config.data?.get("project") || {})["data"] || {},
   );
 
   // find any and all keys which are a registry


### PR DESCRIPTION
Closes #18 

This adds support for discovering `.npmrc` in alternative locations if not found at repo root. 

The alternative I have added is Rush's default `.npmrc` location.

Slight refactor, to split out resovling a `.npmrc` fromt the function that also attempts to read data from it.