### PR TITLE
fix: stop swallowing errors from azureauth

### DIFF
--- a/packages/ado-npm-auth/src/azureauth/ado.ts
+++ b/packages/ado-npm-auth/src/azureauth/ado.ts
@@ -95,7 +95,11 @@ export const adoPat = async (
     }
 
     if (options.output === "json") {
-      return JSON.parse(result.stdout) as AdoPatResponse;
+      try {
+        return JSON.parse(result.stdout) as AdoPatResponse;
+      } catch (error: any) {
+        throw new Error(`Failed to parse JSON output: ${result.stdout}`);
+      }
     }
 
     return result.stdout;


### PR DESCRIPTION
At the moment, if we get an error from AzureAuth and not a JSON, we throw an irrelevant error saying "Encountered error while performing auth Error: Unexpected end of JSON input", this PR fixes that and throws the actual string we received.

I'm hesitating whether we should assert on something specific there inside the `catch` to make sure we're not printing tokens. Any thoughts?