### PR TITLE
Always use public registry for npm exec azureauth

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "private": "true",
   "workspaces": ["packages/*"],
   "scripts": {
-    
+    "build": "lage build",
+    "bundle": "lage bundle",
+    "lint": "lage lint",
+    "test": "lage test"
   },
   "devDependencies": {
     "lage": "^2.7.12",

--- a/packages/ado-npm-auth/README.md
+++ b/packages/ado-npm-auth/README.md
@@ -12,14 +12,6 @@ You can run the binary `"ado-npm-auth"` via `yarn ado-npm-auth` or `npm exec ado
 
 It will then shell out to the `azureauth` package on [npm](https://www.npmjs.com/package/azureauth), retrieve a token, and update your `~/.npmrc`.
 
-## Beware the chicken and egg problem
-
-You may need to set the registry to the public NPM feed when running `npm exec` or `npx`. 
-
-If that's the case, set the environment variable `npm_config_registry=https://registry.npmjs.org`. 
-
-That will ensure that `npx` or `npm exec` grabs from the public NPM feed, bypassing the soon-to-be authenticated ADO feed. 
-
 ## ado-npm-auth vs vsts-npm-auth
 
 The main difference between the two is how they function, and where they can run. The `vsts-npm-auth` tool is Windows only, and uses MSAL authentication.

--- a/packages/ado-npm-auth/src/azureauth/ado.ts
+++ b/packages/ado-npm-auth/src/azureauth/ado.ts
@@ -41,8 +41,10 @@ export const adoPat = async (
     );
   }
 
+  const { command: authCommand, env } = azureAuthCommand();
+
   const command = [
-    ...azureAuthCommand(),
+    ...authCommand,
     `ado`,
     `pat`,
     `--prompt-hint ${isWsl() ? options.promptHint : `"${options.promptHint}"`}`, // We only use spawn for WSL. spawn does not does not require prompt hint to be wrapped in quotes. exec does.
@@ -83,12 +85,7 @@ export const adoPat = async (
       }
     } else {
       try {
-        result = await exec(command.join(" "), {
-          env: {
-            ...process.env,
-            npm_config_registry: "https://registry.npmjs.org",
-          },
-        });
+        result = await exec(command.join(" "), { env });
 
         if (result.stderr) {
           throw new Error(result.stderr);

--- a/packages/ado-npm-auth/src/azureauth/azureauth-command.ts
+++ b/packages/ado-npm-auth/src/azureauth/azureauth-command.ts
@@ -6,11 +6,7 @@ export const clearMemo = () => {
   memo = void 0;
 };
 
-/**
- * Get the executable path of azureauth command
- * @returns { string } the string of the executable command to run azureauth
- */
-export const npxAzureAuthCommand: string[] = [
+const npxAzureAuthCommand: string[] = [
   "npm",
   "exec",
   "--silent",
@@ -18,11 +14,24 @@ export const npxAzureAuthCommand: string[] = [
   "azureauth",
   "--",
 ];
+const npxEnv = {
+  ...process.env,
+  // Use the version from the public registry to avoid a cycle
+  npm_config_registry: "https://registry.npmjs.org",
+};
 
-export const azureAuthCommand = () => {
+/**
+ * Get the executable path of azureauth command
+ * @returns the string of the executable command to run azureauth, and any
+ * necessary environment variables if using npx
+ */
+export const azureAuthCommand = (): {
+  command: string[];
+  env: Record<string, string>;
+} => {
   if (!memo) {
     memo = isWsl() ? ["azureauth.exe"] : npxAzureAuthCommand;
   }
 
-  return memo;
+  return { command: memo, env: npxEnv };
 };

--- a/packages/ado-npm-auth/src/azureauth/is-azureauth-installed.ts
+++ b/packages/ado-npm-auth/src/azureauth/is-azureauth-installed.ts
@@ -13,10 +13,11 @@ export const clearMemo = () => {
  */
 export const isAzureAuthInstalled = async (): Promise<boolean> => {
   if (memo === undefined) {
-    const command = `${azureAuthCommand().join(" ")} --version`;
+    const { command: authCommand, env } = azureAuthCommand();
+    const command = `${authCommand.join(" ")} --version`;
 
     try {
-      const result = await exec(command);
+      const result = await exec(command, { env });
       // version must be >=0.8.0.0
       const [, minor] = result.stdout.split(".");
       memo = parseInt(minor) >= 8;

--- a/packages/ado-npm-auth/src/utils/get-feed-without-protocol.ts
+++ b/packages/ado-npm-auth/src/utils/get-feed-without-protocol.ts
@@ -1,9 +1,7 @@
 /**
  * Given the feed url, get the name of the feed without the protocol ("https") at the beginning
- * @param {string} feed
- * @returns {string}
  */
-export const getFeedWithoutProtocol = (feed: string) => {
+export const getFeedWithoutProtocol = (feed: string): string => {
   const feedUrl = new URL(feed);
   const protocol = feedUrl.protocol; // will be something like "http:"
   const protocolLength = protocol.length + 2; // we want to strip out the protocol, colon, and double slash


### PR DESCRIPTION
The public registry was being used for `npm exec azureauth` when actually running the command, but not when checking if it's installed. This led to an incorrect message "Error: AzureAuth is not installed" when actually it was installed.

This PR updates `azureAuthCommand()` to also return the `env` with `npm_config_registry` set, and updates the calling code to pass it through.

I also updated the repo root package.json to have scripts for repo-wide build/test/etc.

(I'm guessing the `pnpm-lock.yaml` updates were caused by me having a different local pnpm version than whoever set up the repo. The PR build also failed without the lock file updates, so if you'd like to lock to an earlier pnpm version, that should probably be specified using corepack.)