### PR TITLE
Include all types in ado-npm-auth

### DIFF
--- a/change/change-385e965c-981b-43e9-af51-4fffac62eefd.json
+++ b/change/change-385e965c-981b-43e9-af51-4fffac62eefd.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "minor",
+      "comment": "Ensure all types are included in the package",
+      "packageName": "ado-npm-auth",
+      "email": "dannyvv@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/ado-npm-auth/package.json
+++ b/packages/ado-npm-auth/package.json
@@ -13,7 +13,7 @@
   "files": [
     "dist/index.js",
     "dist/ado-npm-auth.cjs",
-    "lib/*.d.ts",
+    "lib/**/*.d.ts",
     "bin",
     "static",
     "LICENCSE.txt",


### PR DESCRIPTION
In pr #48 I that not all .d.ts files types  where included in the package.