### PR TITLE
Add support to pass an override for azureAuthLocation on the commandline

### DIFF
--- a/change/change-9e2cbc00-db38-4fa4-8649-6ce6980de155.json
+++ b/change/change-9e2cbc00-db38-4fa4-8649-6ce6980de155.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Add support to pass an override for azureAuthLocation on the commandline",
+      "packageName": "ado-npm-auth",
+      "email": "dsfsdf@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/ado-npm-auth/src/args.ts
+++ b/packages/ado-npm-auth/src/args.ts
@@ -5,6 +5,7 @@ export interface Args {
   doValidCheck: boolean;
   skipAuth: boolean;
   configFile?: string;
+  azureAuthLocation?: string;
 }
 
 export function parseArgs(args: string[]): Args {
@@ -23,6 +24,10 @@ export function parseArgs(args: string[]): Args {
         type: "string",
         description: "Skip checking the validity of the feeds",
       },
+      azureAuthLocation: {
+        type: "string",
+        description: "Allow specifying alternate location to azureauth"
+      }
     })
     .help()
     .parseSync();
@@ -31,5 +36,6 @@ export function parseArgs(args: string[]): Args {
     skipAuth: argv.skipAuth || false,
     doValidCheck: !argv.skipCheck,
     configFile: argv.configFile,
+    azureAuthLocation: argv.azureAuthLocation,
   };
 }

--- a/packages/ado-npm-auth/src/cli.ts
+++ b/packages/ado-npm-auth/src/cli.ts
@@ -57,7 +57,7 @@ export const run = async (args: Args): Promise<null | boolean> => {
     // get a token for each feed
     const organizationPatMap: Record<string, string> = {};
     for (const adoOrg of adoOrgs) {
-      organizationPatMap[adoOrg] = await generateNpmrcPat(adoOrg, false);
+      organizationPatMap[adoOrg] = await generateNpmrcPat(adoOrg, false, args.azureAuthLocation);
     }
 
     // Update the pat in the invalid feeds.


### PR DESCRIPTION
Previously we added support to override `azureAuthLocation` in the API, this extends supports to the CLI. 
This will make testing auth issues easier as one can just link direclty to a locally installed azureauth instance -or- when developing locally to the bin script of the local project.