### PR TITLE
Allow non azure devops feeds to be present in the configuration

### DIFF
--- a/change/change-a91d72df-b1f7-4fb5-8632-3f0e3e68c110.json
+++ b/change/change-a91d72df-b1f7-4fb5-8632-3f0e3e68c110.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Allow non azure devops feeds to be present in the configuration.",
+      "packageName": "ado-npm-auth",
+      "email": "dannyvv@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/ado-npm-auth/src/cli.ts
+++ b/packages/ado-npm-auth/src/cli.ts
@@ -24,7 +24,9 @@ export const run = async (args: Args): Promise<null | boolean> => {
     }
   }
 
-  const invalidFeeds = validatedFeeds.filter((feed) => !feed.isValid);
+  // Filter to feeds to only feeds that were not authenticated and are actually
+  // azure devops feeds by checking if we discovered the adoOrganization for it.
+  const invalidFeeds = validatedFeeds.filter((feed) => !feed.isValid && feed.feed.adoOrganization);
   const invalidFeedCount = invalidFeeds.length;
 
   if (args.doValidCheck && invalidFeedCount == 0) {


### PR DESCRIPTION
The code was trying to refresh ADO tokens for all feeds, including non-ADO feeds like npmjs.org...
This change will now filter out non-ado feeds when trying to refresh tokens.