### PR TITLE
Handle case where there is no user .yamlrc.yml file present

### DIFF
--- a/change/change-468818d2-785d-40e9-89de-88dddb79d2bb.json
+++ b/change/change-468818d2-785d-40e9-89de-88dddb79d2bb.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "none",
+      "comment": "fix formatting of accidentally merged pr",
+      "packageName": "ado-npm-auth",
+      "email": "dannyvv@microsoft.com",
+      "dependentChangeType": "none"
+    }
+  ]
+}


### PR DESCRIPTION
When adding support for .yarnrc files in a previous commit a use case was missed.
This duplicates the logic of .npmrc where the user profile .yarnrc file is initialized empty if not present or if present the actual default hard-coded feed registration is removed to ensure compliance with Microsoft Security (SFI) requirements