### PR TITLE
Add flag to enable write scope to the generated PAT

### DIFF
--- a/packages/ado-npm-auth/src/args.ts
+++ b/packages/ado-npm-auth/src/args.ts
@@ -6,6 +6,7 @@ export interface Args {
   skipAuth: boolean;
   configFile?: string;
   azureAuthLocation?: string;
+  writeAccess?: boolean;
 }
 
 export function parseArgs(args: string[]): Args {
@@ -28,6 +29,11 @@ export function parseArgs(args: string[]): Args {
         type: "string",
         description: "Allow specifying alternate location to azureauth",
       },
+      writeAccess: {
+        alias: "w",
+        type: "boolean",
+        description: "Create a PAT with write access",
+      },
     })
     .help()
     .parseSync();
@@ -37,5 +43,6 @@ export function parseArgs(args: string[]): Args {
     doValidCheck: !argv.skipCheck,
     configFile: argv.configFile,
     azureAuthLocation: argv.azureAuthLocation,
+    writeAccess: argv.writeAccess,
   };
 }

--- a/packages/ado-npm-auth/src/cli.ts
+++ b/packages/ado-npm-auth/src/cli.ts
@@ -65,6 +65,7 @@ export const run = async (args: Args): Promise<null | boolean> => {
         adoOrg,
         false,
         args.azureAuthLocation,
+        args.writeAccess,
       );
     }
 

--- a/packages/ado-npm-auth/src/npmrc/generate-npmrc-pat.ts
+++ b/packages/ado-npm-auth/src/npmrc/generate-npmrc-pat.ts
@@ -10,6 +10,7 @@ export const generateNpmrcPat = async (
   organization: string,
   encode = false,
   azureAuthLocation?: string,
+  writeAccess = false,
 ): Promise<string> => {
   const name = `${hostname()}-${organization}`;
   const pat = await adoPat(
@@ -17,7 +18,7 @@ export const generateNpmrcPat = async (
       promptHint: `${name} .npmrc PAT`,
       organization,
       displayName: `${name}-npmrc-pat`,
-      scope: ["vso.packaging"],
+      scope: writeAccess ? ["vso.packaging_write"] : ["vso.packaging"],
       timeout: "30",
       output: "json",
     },


### PR DESCRIPTION
Example usage: `ado-npm-auth -w --registry=https://registry.npmjs.org`