### PR TITLE
Fix exit code check in WSL environments

### DIFF
--- a/change/change-dc308d65-6222-40d9-b345-3ed61cb5d0e7.json
+++ b/change/change-dc308d65-6222-40d9-b345-3ed61cb5d0e7.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Fix exit code check in WSL environments",
+      "packageName": "ado-npm-auth",
+      "email": "mantiquillal@gmail.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/ado-npm-auth/src/azureauth/ado.test.ts
+++ b/packages/ado-npm-auth/src/azureauth/ado.test.ts
@@ -1,8 +1,8 @@
-import { expect, test, vi, beforeEach } from "vitest";
-import { AdoPatResponse, adoPat } from "./ado.js";
-import { exec } from "../utils/exec.js";
 import { spawnSync } from "child_process";
+import { beforeEach, expect, test, vi } from "vitest";
+import { exec } from "../utils/exec.js";
 import * as utils from "../utils/is-wsl.js";
+import { AdoPatResponse, adoPat } from "./ado.js";
 
 vi.mock("child_process", async () => {
   return {

--- a/packages/ado-npm-auth/src/azureauth/ado.ts
+++ b/packages/ado-npm-auth/src/azureauth/ado.ts
@@ -81,7 +81,7 @@ export const adoPat = async (
       try {
         result = spawnSync(command[0], command.slice(1), { encoding: "utf-8" });
 
-        if (result.status === 0 || (result.stderr && !result.stdout)) {
+        if (result.status !== 0 || (result.stderr && !result.stdout)) {
           throw new Error(
             `Azure Auth failed with exit code ${result.status}: ${result.stderr}`,
           );


### PR DESCRIPTION
When using this CLI tool to authenticate against the Azure DevOps NPM Artifacts feed in WSL environments, we throw an error even when the token was successfully obtained. We check if the status code is `0` and if so, we throw an error. We should actually be checking if the status code is not `0` as `0` indicates a successful execution of the process.
- Fix if statement condition in WSL environments.
- Add changefiles.
- Add unit tests.