### PR TITLE
Add a new CLI flag to allow the user to specify a custom exit code

### DIFF
--- a/change/change-72abf428-c4ea-439b-bc1e-4f77dc37ce7d.json
+++ b/change/change-72abf428-c4ea-439b-bc1e-4f77dc37ce7d.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "minor",
+      "comment": "Add new flag to return a specific exit code when authentication ran",
+      "packageName": "ado-npm-auth",
+      "email": "dannyvv@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/ado-npm-auth/src/args.ts
+++ b/packages/ado-npm-auth/src/args.ts
@@ -6,6 +6,7 @@ export interface Args {
   skipAuth: boolean;
   configFile?: string;
   azureAuthLocation?: string;
+  exitCodeOnReAuthenticate?: number;
 }
 
 export function parseArgs(args: string[]): Args {
@@ -28,6 +29,10 @@ export function parseArgs(args: string[]): Args {
         type: "string",
         description: "Allow specifying alternate location to azureauth",
       },
+      exitCodeOnReAuthenticate: {
+        type: "number",
+        description: "Exit when re-authentication occurs",
+      },
     })
     .help()
     .parseSync();
@@ -37,5 +42,6 @@ export function parseArgs(args: string[]): Args {
     doValidCheck: !argv.skipCheck,
     configFile: argv.configFile,
     azureAuthLocation: argv.azureAuthLocation,
+    exitCodeOnReAuthenticate: argv.exitCodeOnReAuthenticate,
   };
 }

--- a/packages/ado-npm-auth/src/cli.ts
+++ b/packages/ado-npm-auth/src/cli.ts
@@ -138,6 +138,10 @@ run(args)
       // advertise success
       logTelemetry({ success: true, automaticSuccess: true });
       console.log("✅ Automatic authentication successful");
+      // if the user specified an exit code for reauthenticate, exit
+      if (args.exitCodeOnReAuthenticate) {
+        process.exit(args.exitCodeOnReAuthenticate);
+      }
     } else {
       // automatic auth failed (for some reason)
       // advertise failure and link wiki to fix

--- a/packages/ado-npm-auth/src/cli.ts
+++ b/packages/ado-npm-auth/src/cli.ts
@@ -139,7 +139,7 @@ run(args)
       logTelemetry({ success: true, automaticSuccess: true });
       console.log("✅ Automatic authentication successful");
       // if the user specified an exit code for reauthenticate, exit
-      if (args.exitCodeOnReAuthenticate) {
+      if (args.exitCodeOnReAuthenticate !== undefined) {
         process.exit(args.exitCodeOnReAuthenticate);
       }
     } else {


### PR DESCRIPTION
Add a new CLI flag to allow the user to specify a custom exit code that gets returned when ado-npm-auth had to re-authenticate. This is useful when one uses a prerelease step to call ado-npm-auth after which yarn has already parsed the configuration and tokens. So the first time the install will fail with a 401, but the second time it will work. This way a prerelease script can be used to make sure yarn is stopped and asked to rerun.