### PR TITLE
Add Linux support to ado-npm-auth and node-azureauth

### DIFF
--- a/packages/ado-npm-auth/src/azureauth/is-supported-platform-and-architecture.ts
+++ b/packages/ado-npm-auth/src/azureauth/is-supported-platform-and-architecture.ts
@@ -2,13 +2,14 @@ import { arch, platform } from "os";
 import { isWsl } from "../utils/is-wsl.js";
 
 /**
- * Determines if the currently running platform is supported by azureauth. Currently, supported platforms are Windows, Mac & WSL
+ * Determines if the currently running platform is supported by azureauth. Currently, supported platforms are Windows, Mac, Linux & WSL
  * @returns { boolean } if the current platform is supported by azureauth
  */
 export const isSupportedPlatformAndArchitecture = (): boolean => {
   const supportedPlatformsAndArchitectures: Record<string, string[]> = {
     win32: ["x64"],
     darwin: ["x64", "arm64"],
+    linux: ["x64", "arm64"],
   };
 
   return (


### PR DESCRIPTION
## Summary
Enables native Linux (x64 and arm64) support for automatic Azure DevOps authentication. The `azureauth` CLI already provides Linux binaries (v0.8.4+), but the wrapper packages were blocking Linux users.

## Changes

### packages/ado-npm-auth
- Added `linux: ["x64", "arm64"]` to supported platforms in `is-supported-platform-and-architecture.ts`
- Updated JSDoc to reflect Linux support

### packages/node-azureauth  
- Added `linux: ["x64", "arm64"]` to supported platforms
- Fixed `AZUREAUTH_NAME_MAP` for Linux (binary name is `azureauth`, not `azureauth.exe`)
- Added Linux `.deb` download support to `DOWNLOAD_MAP`:
  - `azureauth-0.8.4-linux-x64.deb`
  - `azureauth-0.8.4-linux-arm64.deb`
- Implemented `extractDeb()` function to handle Debian package extraction:
  - Extracts `ar` archive
  - Finds and extracts `data.tar.*`
  - Copies all files from `/usr/lib/azureauth/` to install directory
  - Sets proper permissions (0o755)

## Testing
Tested on Arch Linux x64:
- ✅ Binary downloads successfully (v0.8.4)
- ✅ Binary extracts and installs correctly  
- ✅ Authentication completes successfully
- ✅ No regression for Windows/macOS/WSL (WSL still uses Windows .exe via interop)

## Before/After
**Before:** Linux users see "Platform linux and architecture x64 not supported" error  
**After:** Linux users can use `npm exec azureauth` for automatic authentication

## Notes
- WSL continues to use Windows executable (`azureauth.exe`) via WSL interop as before
- Only native Linux distributions benefit from this change
- Requires `ar` and `tar` commands (standard on all Linux distributions)