### PR TITLE
Add authentication support for Linux

### DIFF
--- a/change/change-93b7b060-7b85-4c0b-8bc8-961d5ceef53e.json
+++ b/change/change-93b7b060-7b85-4c0b-8bc8-961d5ceef53e.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "minor",
+      "comment": "Add authentication support for Linux",
+      "packageName": "ado-npm-auth",
+      "email": "dannyvv@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/ado-npm-auth/.gitignore
+++ b/packages/ado-npm-auth/.gitignore
@@ -1,2 +1,3 @@
 dist
 lib
+.bin

--- a/packages/ado-npm-auth/src/cli.ts
+++ b/packages/ado-npm-auth/src/cli.ts
@@ -51,18 +51,17 @@ export const run = async (args: Args): Promise<null | boolean> => {
   try {
     console.log("🔑 Authenticating to package feed...");
 
-    const adoOrgs = new Set<string>();
-    for (const adoOrg of invalidFeeds.map(
-      (feed) => feed.feed.adoOrganization,
-    )) {
-      adoOrgs.add(adoOrg);
+    const feedsToGetTokenFor = new Map<string, string>();
+    for (const feed of invalidFeeds.map((feed) => feed.feed)) {
+      feedsToGetTokenFor.set(feed.adoOrganization, feed.registry);
     }
 
     // get a token for each feed
     const organizationPatMap: Record<string, string> = {};
-    for (const adoOrg of adoOrgs) {
-      organizationPatMap[adoOrg] = await generateNpmrcPat(
-        adoOrg,
+    for (const [org, feed] of feedsToGetTokenFor) {
+      organizationPatMap[org] = await generateNpmrcPat(
+        org,
+        feed,
         false,
         args.azureAuthLocation,
       );

--- a/packages/ado-npm-auth/src/npmrc/generate-npmrc-pat.ts
+++ b/packages/ado-npm-auth/src/npmrc/generate-npmrc-pat.ts
@@ -14,7 +14,12 @@ export const generateNpmrcPat = async (
   azureAuthLocation?: string,
 ): Promise<string> => {
   const name = `${hostname()}-${organization}`;
-  const rawToken = await getRawToken(name, organization, feed, azureAuthLocation);
+  const rawToken = await getRawToken(
+    name,
+    organization,
+    feed,
+    azureAuthLocation,
+  );
 
   if (encode) {
     return toBase64(rawToken);
@@ -23,8 +28,12 @@ export const generateNpmrcPat = async (
   return rawToken;
 };
 
-
-async function getRawToken(name: string, organization: string, feed: string, azureAuthLocation?: string): Promise<string> {
+async function getRawToken(
+  name: string,
+  organization: string,
+  feed: string,
+  azureAuthLocation?: string,
+): Promise<string> {
   switch (platform()) {
     case "win32":
     case "darwin":
@@ -40,7 +49,7 @@ async function getRawToken(name: string, organization: string, feed: string, azu
       );
       return (pat as AdoPatResponse).token;
     case "linux":
-      const cpPat = await credentialProviderPat(feed)
+      const cpPat = await credentialProviderPat(feed);
       return cpPat.Password;
     default:
       throw new Error(

--- a/packages/ado-npm-auth/src/npmrc/nugetCredentialProvider.ts
+++ b/packages/ado-npm-auth/src/npmrc/nugetCredentialProvider.ts
@@ -4,84 +4,119 @@ import path from "path";
 import { downloadFile } from "../utils/request.js";
 import { execProcess } from "../utils/exec.js";
 
-const OutputDir = path.join(__dirname, "..", ".bin", "CredentialProvider.Microsoft");
+const OutputDir = path.join(
+  __dirname,
+  "..",
+  ".bin",
+  "CredentialProvider.Microsoft",
+);
 const CredentialProviderVersion = "1.4.1";
 
 interface CredentialProviderResponse {
-    Username: string;
-    Password: string;
+  Username: string;
+  Password: string;
 }
 
-export async function credentialProviderPat(registry: string): Promise<CredentialProviderResponse> {
-    const nugetFeedUrl = toNugetUrl(registry);
-    const toolPath = await getCredentialProvider();
-    return await invokeCredentialProvider(toolPath, nugetFeedUrl);
+export async function credentialProviderPat(
+  registry: string,
+): Promise<CredentialProviderResponse> {
+  const nugetFeedUrl = toNugetUrl(registry);
+  const toolPath = await getCredentialProvider();
+  return await invokeCredentialProvider(toolPath, nugetFeedUrl);
 }
 
 function toNugetUrl(registry: string): string {
-    if (!registry.endsWith("/npm/registry/")) {
-        throw new Error(`Registry URL ${registry} is not a valid Azure Artifacts npm registry URL. Expected it to end with '/npm/registry/'`);
-    }
-    return "https://" + registry.replace("/npm/registry/", "/nuget/v3/index.json")
+  if (!registry.endsWith("/npm/registry/")) {
+    throw new Error(
+      `Registry URL ${registry} is not a valid Azure Artifacts npm registry URL. Expected it to end with '/npm/registry/'`,
+    );
+  }
+  return (
+    "https://" + registry.replace("/npm/registry/", "/nuget/v3/index.json")
+  );
 }
 
-async function invokeCredentialProvider(toolPath: string, nugetFeedUrl: string): Promise<CredentialProviderResponse> {
-    let response = "";
-    await execProcess(toolPath, ["-U", nugetFeedUrl, "-I", "-F", "Json"], {
-        stdio: "pipe",
-        processStdOut: (data: string) => {
-            response += data;
-        },
-        processStdErr: (data: string) => {
-            console.error(data);
-        }
-    });
-    try {
-        let value = JSON.parse(response);
-        return value as CredentialProviderResponse
-    } catch (error) {
-        throw new Error(`Failed to parse CredentialProvider output: ${response}`);
-    }
+async function invokeCredentialProvider(
+  toolPath: string,
+  nugetFeedUrl: string,
+): Promise<CredentialProviderResponse> {
+  let response = "";
+  await execProcess(toolPath, ["-U", nugetFeedUrl, "-I", "-F", "Json"], {
+    stdio: "pipe",
+    processStdOut: (data: string) => {
+      response += data;
+    },
+    processStdErr: (data: string) => {
+      console.error(data);
+    },
+  });
+  try {
+    let value = JSON.parse(response);
+    return value as CredentialProviderResponse;
+  } catch (error) {
+    throw new Error(`Failed to parse CredentialProvider output: ${response}`);
+  }
 }
 
 function tryFileExists(executable: string): string | undefined {
-    if (fs.existsSync(executable)) {
-        return executable;
-    } else if (fs.existsSync(executable + ".exe")) {
-        return executable + ".exe";
-    }
-    return undefined;
+  if (fs.existsSync(executable)) {
+    return executable;
+  } else if (fs.existsSync(executable + ".exe")) {
+    return executable + ".exe";
+  }
+  return undefined;
 }
 
 async function getCredentialProvider(): Promise<string> {
-    let toolPath = tryFileExists(path.join(os.homedir(), ".nuget", "plugins", "netcore", "CredentialProvider.Microsoft", "CredentialProvider.Microsoft"));
-    if (toolPath) {
-        return toolPath;
-    }
-
-    const downloadedFilePath = path.join(OutputDir, "plugins", "netcore", "CredentialProvider.Microsoft", "CredentialProvider.Microsoft");
-    toolPath = tryFileExists(downloadedFilePath);
-    if (toolPath) {
-        return toolPath;
-    }
-
-    await downloadCredentialProvider();
-    toolPath = tryFileExists(downloadedFilePath);
-    if (toolPath) {
-        fs.chmodSync(toolPath, 0o755);
-    } else {
-        throw new Error(`CredentialProvider was not found at expected path after download: ${toolPath}`);
-    }
-
+  let toolPath = tryFileExists(
+    path.join(
+      os.homedir(),
+      ".nuget",
+      "plugins",
+      "netcore",
+      "CredentialProvider.Microsoft",
+      "CredentialProvider.Microsoft",
+    ),
+  );
+  if (toolPath) {
     return toolPath;
+  }
+
+  const downloadedFilePath = path.join(
+    OutputDir,
+    "plugins",
+    "netcore",
+    "CredentialProvider.Microsoft",
+    "CredentialProvider.Microsoft",
+  );
+  toolPath = tryFileExists(downloadedFilePath);
+  if (toolPath) {
+    return toolPath;
+  }
+
+  await downloadCredentialProvider();
+  toolPath = tryFileExists(downloadedFilePath);
+  if (toolPath) {
+    fs.chmodSync(toolPath, 0o755);
+  } else {
+    throw new Error(
+      `CredentialProvider was not found at expected path after download: ${toolPath}`,
+    );
+  }
+
+  return toolPath;
 }
 
 async function downloadCredentialProvider(): Promise<void> {
-    const downloadUrl = `https://github.com/microsoft/artifacts-credprovider/releases/download/v${CredentialProviderVersion}/Microsoft.Net8.${os.platform()}-${os.arch()}.NuGet.CredentialProvider.tar.gz`
-    const downloadPath = path.join(OutputDir, "CredentialProvider.Microsoft.tar.gz");
+  const downloadUrl = `https://github.com/microsoft/artifacts-credprovider/releases/download/v${CredentialProviderVersion}/Microsoft.Net8.${os.platform()}-${os.arch()}.NuGet.CredentialProvider.tar.gz`;
+  const downloadPath = path.join(
+    OutputDir,
+    "CredentialProvider.Microsoft.tar.gz",
+  );
 
-    console.log(`🌐 Downloading ${downloadUrl}`);
-    await downloadFile(downloadUrl, downloadPath);
-    await execProcess("tar", ["-xzf", downloadPath, "-C", OutputDir], { stdio: "inherit" });
+  console.log(`🌐 Downloading ${downloadUrl}`);
+  await downloadFile(downloadUrl, downloadPath);
+  await execProcess("tar", ["-xzf", downloadPath, "-C", OutputDir], {
+    stdio: "inherit",
+  });
 }
-

--- a/packages/ado-npm-auth/src/npmrc/nugetCredentialProvider.ts
+++ b/packages/ado-npm-auth/src/npmrc/nugetCredentialProvider.ts
@@ -4,13 +4,14 @@ import path from "path";
 import { downloadFile } from "../utils/request.js";
 import { execProcess } from "../utils/exec.js";
 
+const CredentialProviderVersion = "1.4.1";
 const OutputDir = path.join(
   __dirname,
   "..",
   ".bin",
   "CredentialProvider.Microsoft",
+  "v" + CredentialProviderVersion
 );
-const CredentialProviderVersion = "1.4.1";
 
 interface CredentialProviderResponse {
   Username: string;

--- a/packages/ado-npm-auth/src/npmrc/nugetCredentialProvider.ts
+++ b/packages/ado-npm-auth/src/npmrc/nugetCredentialProvider.ts
@@ -10,7 +10,7 @@ const OutputDir = path.join(
   "..",
   ".bin",
   "CredentialProvider.Microsoft",
-  "v" + CredentialProviderVersion
+  "v" + CredentialProviderVersion,
 );
 
 interface CredentialProviderResponse {

--- a/packages/ado-npm-auth/src/npmrc/nugetCredentialProvider.ts
+++ b/packages/ado-npm-auth/src/npmrc/nugetCredentialProvider.ts
@@ -1,0 +1,87 @@
+import os from "os";
+import fs from "fs";
+import path from "path";
+import { downloadFile } from "../utils/request.js";
+import { execProcess } from "../utils/exec.js";
+
+const OutputDir = path.join(__dirname, "..", ".bin", "CredentialProvider.Microsoft");
+const CredentialProviderVersion = "1.4.1";
+
+interface CredentialProviderResponse {
+    Username: string;
+    Password: string;
+}
+
+export async function credentialProviderPat(registry: string): Promise<CredentialProviderResponse> {
+    const nugetFeedUrl = toNugetUrl(registry);
+    const toolPath = await getCredentialProvider();
+    return await invokeCredentialProvider(toolPath, nugetFeedUrl);
+}
+
+function toNugetUrl(registry: string): string {
+    if (!registry.endsWith("/npm/registry/")) {
+        throw new Error(`Registry URL ${registry} is not a valid Azure Artifacts npm registry URL. Expected it to end with '/npm/registry/'`);
+    }
+    return "https://" + registry.replace("/npm/registry/", "/nuget/v3/index.json")
+}
+
+async function invokeCredentialProvider(toolPath: string, nugetFeedUrl: string): Promise<CredentialProviderResponse> {
+    let response = "";
+    await execProcess(toolPath, ["-U", nugetFeedUrl, "-I", "-F", "Json"], {
+        stdio: "pipe",
+        processStdOut: (data: string) => {
+            response += data;
+        },
+        processStdErr: (data: string) => {
+            console.error(data);
+        }
+    });
+    try {
+        let value = JSON.parse(response);
+        return value as CredentialProviderResponse
+    } catch (error) {
+        throw new Error(`Failed to parse CredentialProvider output: ${response}`);
+    }
+}
+
+function tryFileExists(executable: string): string | undefined {
+    if (fs.existsSync(executable)) {
+        return executable;
+    } else if (fs.existsSync(executable + ".exe")) {
+        return executable + ".exe";
+    }
+    return undefined;
+}
+
+async function getCredentialProvider(): Promise<string> {
+    let toolPath = tryFileExists(path.join(os.homedir(), ".nuget", "plugins", "netcore", "CredentialProvider.Microsoft", "CredentialProvider.Microsoft"));
+    if (toolPath) {
+        return toolPath;
+    }
+
+    const downloadedFilePath = path.join(OutputDir, "plugins", "netcore", "CredentialProvider.Microsoft", "CredentialProvider.Microsoft");
+    toolPath = tryFileExists(downloadedFilePath);
+    if (toolPath) {
+        return toolPath;
+    }
+
+    await downloadCredentialProvider();
+    toolPath = tryFileExists(downloadedFilePath);
+    if (toolPath) {
+        fs.chmodSync(toolPath, 0o755);
+    } else {
+        throw new Error(`CredentialProvider was not found at expected path after download: ${toolPath}`);
+    }
+
+    return toolPath;
+}
+
+async function downloadCredentialProvider(): Promise<void> {
+    const downloadUrl = `https://github.com/microsoft/artifacts-credprovider/releases/download/v${CredentialProviderVersion}/Microsoft.Net8.${os.platform()}-${os.arch()}.NuGet.CredentialProvider.tar.gz`
+    const downloadPath = path.join(OutputDir, "CredentialProvider.Microsoft.tar.gz");
+
+    console.log(`🌐 Downloading ${downloadUrl}`);
+    await downloadFile(downloadUrl, downloadPath);
+    await execProcess("tar", ["-xzf", downloadPath, "-C", OutputDir], { stdio: "inherit" });
+}
+

--- a/packages/ado-npm-auth/src/utils/exec.ts
+++ b/packages/ado-npm-auth/src/utils/exec.ts
@@ -11,48 +11,46 @@ export const exec = promisify(_exec);
  * @returns A promise that resolves when the process exits.
  */
 export function execProcess(
-    tool: string,
-    args: string[],
-    options?: {
-        cwd?: string;
-        env?: { [key: string]: string };
-        stdio?: "pipe" | "inherit" | "ignore";
-        shell?: boolean | string;
-        processStdOut?: (data: string) => void;
-        processStdErr?: (data: string) => void;
-    },
+  tool: string,
+  args: string[],
+  options?: {
+    cwd?: string;
+    env?: { [key: string]: string };
+    stdio?: "pipe" | "inherit" | "ignore";
+    shell?: boolean | string;
+    processStdOut?: (data: string) => void;
+    processStdErr?: (data: string) => void;
+  },
 ): Promise<void> {
-    return new Promise((resolve, reject) => {
-        const cwd = options?.cwd || process.cwd();
-        console.log(
-            `🚀 Launching  [${tool} ${args.join(" ")}] in ${cwd}`,
-        );
-        const result = spawn(tool, args, {
-            cwd: cwd,
-            env: options?.env || process.env,
-            stdio: options?.stdio || "inherit",
-            shell: options?.shell || false,
-        });
-
-        if (options?.stdio === "pipe") {
-            result.stdout?.setEncoding("utf8");
-            result.stdout?.on("data", function (data: Buffer) {
-                const strData = data.toString("utf8");
-                options?.processStdOut?.(strData);
-            });
-
-            result.stderr?.setEncoding("utf8");
-            result.stderr?.on("data", function (data: Buffer) {
-                const strData = data.toString("utf8");
-                options?.processStdErr?.(strData);
-            });
-        }
-        result.on("exit", (code) => {
-            if (code == 0) {
-                resolve();
-            } else {
-                reject(new Error(`Process ${tool} exited with code ${code}`));
-            }
-        });
+  return new Promise((resolve, reject) => {
+    const cwd = options?.cwd || process.cwd();
+    console.log(`🚀 Launching  [${tool} ${args.join(" ")}] in ${cwd}`);
+    const result = spawn(tool, args, {
+      cwd: cwd,
+      env: options?.env || process.env,
+      stdio: options?.stdio || "inherit",
+      shell: options?.shell || false,
     });
+
+    if (options?.stdio === "pipe") {
+      result.stdout?.setEncoding("utf8");
+      result.stdout?.on("data", function (data: Buffer) {
+        const strData = data.toString("utf8");
+        options?.processStdOut?.(strData);
+      });
+
+      result.stderr?.setEncoding("utf8");
+      result.stderr?.on("data", function (data: Buffer) {
+        const strData = data.toString("utf8");
+        options?.processStdErr?.(strData);
+      });
+    }
+    result.on("exit", (code) => {
+      if (code == 0) {
+        resolve();
+      } else {
+        reject(new Error(`Process ${tool} exited with code ${code}`));
+      }
+    });
+  });
 }

--- a/packages/ado-npm-auth/src/utils/exec.ts
+++ b/packages/ado-npm-auth/src/utils/exec.ts
@@ -1,4 +1,58 @@
-import { exec as _exec } from "node:child_process";
+import { exec as _exec, spawn } from "node:child_process";
 import { promisify } from "node:util";
 
 export const exec = promisify(_exec);
+
+/**
+ * Executes a command as a child process.
+ * @param tool The command to run.
+ * @param args The arguments to pass to the command.
+ * @param options Options for the child process.
+ * @returns A promise that resolves when the process exits.
+ */
+export function execProcess(
+    tool: string,
+    args: string[],
+    options?: {
+        cwd?: string;
+        env?: { [key: string]: string };
+        stdio?: "pipe" | "inherit" | "ignore";
+        shell?: boolean | string;
+        processStdOut?: (data: string) => void;
+        processStdErr?: (data: string) => void;
+    },
+): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const cwd = options?.cwd || process.cwd();
+        console.log(
+            `🚀 Launching  [${tool} ${args.join(" ")}] in ${cwd}`,
+        );
+        const result = spawn(tool, args, {
+            cwd: cwd,
+            env: options?.env || process.env,
+            stdio: options?.stdio || "inherit",
+            shell: options?.shell || false,
+        });
+
+        if (options?.stdio === "pipe") {
+            result.stdout?.setEncoding("utf8");
+            result.stdout?.on("data", function (data: Buffer) {
+                const strData = data.toString("utf8");
+                options?.processStdOut?.(strData);
+            });
+
+            result.stderr?.setEncoding("utf8");
+            result.stderr?.on("data", function (data: Buffer) {
+                const strData = data.toString("utf8");
+                options?.processStdErr?.(strData);
+            });
+        }
+        result.on("exit", (code) => {
+            if (code == 0) {
+                resolve();
+            } else {
+                reject(new Error(`Process ${tool} exited with code ${code}`));
+            }
+        });
+    });
+}

--- a/packages/ado-npm-auth/src/utils/request.ts
+++ b/packages/ado-npm-auth/src/utils/request.ts
@@ -1,4 +1,6 @@
 import https, { RequestOptions } from "https";
+import fs from "fs";
+import path from "path";
 
 const defaultOptions: RequestOptions = {
   port: 443,
@@ -51,3 +53,62 @@ export const makeRequest = async (options: RequestOptions) => {
     req.end();
   });
 };
+
+
+/**
+ * Downloads a file from a URL to a local path.
+ * @param url The URL of the file to download.
+ * @param downloadPath The local path to save the downloaded file.
+ * @returns A promise that resolves when the download is complete.
+ */
+export async function downloadFile(url: string, downloadPath: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        https.get(url, (response) => {
+            // Handle redirects
+            if (response.statusCode === 301 || response.statusCode === 302) {
+                const redirectUrl = response.headers.location;
+                if (redirectUrl) {
+                    downloadFile(redirectUrl, downloadPath).then(resolve).catch(reject);
+                    return;
+                } else {
+                    reject(new Error('Redirect without location header'));
+                    return;
+                }
+            }
+
+            // Check for successful response
+            if (response.statusCode !== 200) {
+                reject(new Error(`HTTP ${response.statusCode}: ${response.statusMessage}`));
+                return;
+            }
+
+            let downloadStream: fs.WriteStream;
+            try {
+                const downloadDir = path.dirname(downloadPath);
+                if (!fs.existsSync(downloadDir)) {
+                    fs.mkdirSync(downloadDir, { recursive: true });
+                }
+
+                downloadStream = fs.createWriteStream(downloadPath);
+            } catch (error) {
+                reject(error);
+                return;
+            }
+
+            // Handle stream errors
+            downloadStream.on('error', (error) => {
+                reject(error);
+            });
+
+            // Pipe the response to the file stream
+            response.pipe(downloadStream);
+
+            // The whole response has been received and written
+            downloadStream.on('finish', () => {
+                resolve();
+            });
+        }).on('error', (error) => {
+            reject(error); // Reject on request error
+        });
+    });
+}

--- a/packages/ado-npm-auth/src/utils/request.ts
+++ b/packages/ado-npm-auth/src/utils/request.ts
@@ -54,61 +54,67 @@ export const makeRequest = async (options: RequestOptions) => {
   });
 };
 
-
 /**
  * Downloads a file from a URL to a local path.
  * @param url The URL of the file to download.
  * @param downloadPath The local path to save the downloaded file.
  * @returns A promise that resolves when the download is complete.
  */
-export async function downloadFile(url: string, downloadPath: string): Promise<void> {
-    return new Promise((resolve, reject) => {
-        https.get(url, (response) => {
-            // Handle redirects
-            if (response.statusCode === 301 || response.statusCode === 302) {
-                const redirectUrl = response.headers.location;
-                if (redirectUrl) {
-                    downloadFile(redirectUrl, downloadPath).then(resolve).catch(reject);
-                    return;
-                } else {
-                    reject(new Error('Redirect without location header'));
-                    return;
-                }
-            }
+export async function downloadFile(
+  url: string,
+  downloadPath: string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, (response) => {
+        // Handle redirects
+        if (response.statusCode === 301 || response.statusCode === 302) {
+          const redirectUrl = response.headers.location;
+          if (redirectUrl) {
+            downloadFile(redirectUrl, downloadPath).then(resolve).catch(reject);
+            return;
+          } else {
+            reject(new Error("Redirect without location header"));
+            return;
+          }
+        }
 
-            // Check for successful response
-            if (response.statusCode !== 200) {
-                reject(new Error(`HTTP ${response.statusCode}: ${response.statusMessage}`));
-                return;
-            }
+        // Check for successful response
+        if (response.statusCode !== 200) {
+          reject(
+            new Error(`HTTP ${response.statusCode}: ${response.statusMessage}`),
+          );
+          return;
+        }
 
-            let downloadStream: fs.WriteStream;
-            try {
-                const downloadDir = path.dirname(downloadPath);
-                if (!fs.existsSync(downloadDir)) {
-                    fs.mkdirSync(downloadDir, { recursive: true });
-                }
+        let downloadStream: fs.WriteStream;
+        try {
+          const downloadDir = path.dirname(downloadPath);
+          if (!fs.existsSync(downloadDir)) {
+            fs.mkdirSync(downloadDir, { recursive: true });
+          }
 
-                downloadStream = fs.createWriteStream(downloadPath);
-            } catch (error) {
-                reject(error);
-                return;
-            }
+          downloadStream = fs.createWriteStream(downloadPath);
+        } catch (error) {
+          reject(error);
+          return;
+        }
 
-            // Handle stream errors
-            downloadStream.on('error', (error) => {
-                reject(error);
-            });
-
-            // Pipe the response to the file stream
-            response.pipe(downloadStream);
-
-            // The whole response has been received and written
-            downloadStream.on('finish', () => {
-                resolve();
-            });
-        }).on('error', (error) => {
-            reject(error); // Reject on request error
+        // Handle stream errors
+        downloadStream.on("error", (error) => {
+          reject(error);
         });
-    });
+
+        // Pipe the response to the file stream
+        response.pipe(downloadStream);
+
+        // The whole response has been received and written
+        downloadStream.on("finish", () => {
+          resolve();
+        });
+      })
+      .on("error", (error) => {
+        reject(error); // Reject on request error
+      });
+  });
 }


### PR DESCRIPTION
[AzureAuth](https://github.com/AzureAD/microsoft-authentication-cli) has dropped support for Linux since 0.9.0 :(
There is still authentication support for authenticating to azure artifacts on linux by the Microsoft Credential provider used by dotnet for nuget authentication.

This change adds support for running the nuget auth tool.

# Related work:

There are 2 active PR's to fix #71.
This PR and #76.
The other PR is the cleaner one, it extends the patterned use of AzureAuth library.
Unfortunately, that library has stopped supporting linux since v9.0.0 :( 
This approach is a lot more ugly and 1-off for linux from the rest.... But it would allow us to use later versions of the library...
I worry that a future compliance pass will require us to update to v9 because it uses a later MSAL library.