### PR TITLE
Fix circular promise references

### DIFF
--- a/change/change-e750e299-3f52-4757-8968-fb45d7ecf356.json
+++ b/change/change-e750e299-3f52-4757-8968-fb45d7ecf356.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Fix circular promise in fetchTokens",
+      "packageName": "@microsoft/yarn-plugin-ado-auth",
+      "email": "masplund@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/yarn-plugin-ado-auth/src/tokenCache.ts
+++ b/packages/yarn-plugin-ado-auth/src/tokenCache.ts
@@ -58,6 +58,8 @@ export class TokenCache {
    */
   private async fetchToken(registry: string, ident?: Ident): Promise<string> {
     const configuration = this.configuration;
+    let token: string | null = null;
+
     await StreamReport.start(
       { configuration, stdout: process.stdout },
       async (report) => {
@@ -70,6 +72,7 @@ export class TokenCache {
         const authConfig = this.getAuthConfiguration(registry, ident);
         const tokenFromYarnrc = getConfigString(authConfig, "npmAuthToken");
         if (tokenFromYarnrc) {
+          token = tokenFromYarnrc;
           this.cache[registry] = tokenFromYarnrc;
           report.reportInfo(
             null,
@@ -91,6 +94,7 @@ export class TokenCache {
           false,
           this.azureAuthPath,
         );
+        token = pat;
         this.cache[registry] = pat;
         report.reportInfo(
           null,
@@ -99,11 +103,10 @@ export class TokenCache {
       },
     );
 
-    const pat = this.cache[registry];
-    if (pat == null) {
+    if (token == null) {
       throw new Error(`Failed to authenticate to: ${registry}`);
     }
-    return pat;
+    return token;
   }
 
   /**


### PR DESCRIPTION
Fix for #131 

Introduce a local variable for the result token so we no longer add and reference the promise that is added to the cache.