### PR TITLE
feat(yarn-plugin-ado-auth): add tenantId/domain config for non-Microsoft tenants

### DIFF
--- a/change/change-657ae75c-b01f-4395-8e53-d53d61cdf7db.json
+++ b/change/change-657ae75c-b01f-4395-8e53-d53d61cdf7db.json
@@ -1,0 +1,18 @@
+{
+  "changes": [
+    {
+      "type": "minor",
+      "comment": "Forward tenant/domain options to azureauth; supports non-Microsoft tenants (fixes #138)",
+      "packageName": "@microsoft/ado-npm-auth-lib",
+      "email": "26187677+Bafff@users.noreply.github.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "minor",
+      "comment": "Forward tenant/domain options to azureauth; supports non-Microsoft tenants (fixes #138)",
+      "packageName": "@microsoft/yarn-plugin-ado-auth",
+      "email": "26187677+Bafff@users.noreply.github.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/ado-npm-auth-lib/src/azureauth/ado.test.ts
+++ b/packages/ado-npm-auth-lib/src/azureauth/ado.test.ts
@@ -1,28 +1,19 @@
 import { spawnSync } from "node:child_process";
 import { beforeEach, expect, test, vi } from "vitest";
-import { exec } from "../utils/exec.js";
 import * as utils from "../utils/is-wsl.js";
 import type { AdoPatResponse } from "./ado.js";
 import { adoPat } from "./ado.js";
+import { clearMemo } from "./azureauth-command.js";
 
 vi.mock("child_process", async () => {
   return {
-    spawnSync: vi.fn(() => {
-      error: {
-      }
-    }),
+    spawnSync: vi.fn(),
   };
 });
 
 vi.mock("./is-azureauth-installed.js", async () => {
   return {
     isAzureAuthInstalled: vi.fn(() => true),
-  };
-});
-
-vi.mock("../utils/exec.js", async () => {
-  return {
-    exec: vi.fn(),
   };
 });
 
@@ -38,18 +29,31 @@ vi.mock("./is-supported-platform-and-architecture.js", async () => {
   };
 });
 
-beforeEach(() => {
-  vi.clearAllMocks();
+let mockedPlatform: NodeJS.Platform = "darwin";
+
+vi.mock("node:os", async () => {
+  const actual = await vi.importActual<typeof import("node:os")>("node:os");
+  return {
+    ...actual,
+    platform: () => mockedPlatform,
+  };
 });
 
-test("it should spawn azureauth", async () => {
+const expectedLauncher = () => (mockedPlatform === "win32" ? "npm.cmd" : "npm");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearMemo();
+  mockedPlatform = "darwin";
+});
+
+test("it should spawnSync azureauth", async () => {
   vi.mocked(utils.isWsl).mockReturnValue(false);
-  vi.mocked(exec).mockReturnValue(
-    Promise.resolve({
-      stdout: '{ "token": "foobarabc123" }',
-      stderr: "",
-    }) as any,
-  );
+  vi.mocked(spawnSync).mockReturnValue({
+    status: 0,
+    stdout: '{ "token": "foobarabc123" }',
+    stderr: "",
+  } as any);
 
   const results = (await adoPat({
     promptHint: "hint",
@@ -61,17 +65,84 @@ test("it should spawn azureauth", async () => {
     timeout: "200",
   })) as AdoPatResponse;
 
-  expect(exec).toHaveBeenCalledWith(
-    'npm exec --silent --yes azureauth -- ado pat --prompt-hint "hint" --organization org --display-name test display --scope foobar --output json --domain baz.com --timeout 200',
-    expect.anything(),
+  expect(spawnSync).toHaveBeenCalledWith(
+    expectedLauncher(),
+    [
+      "exec",
+      "--silent",
+      "--yes",
+      "azureauth",
+      "--",
+      "ado",
+      "pat",
+      "--prompt-hint",
+      "hint",
+      "--organization",
+      "org",
+      "--display-name",
+      "test display",
+      "--scope",
+      "foobar",
+      "--output",
+      "json",
+      "--domain",
+      "baz.com",
+      "--timeout",
+      "200",
+    ],
+    expect.objectContaining({ shell: false }),
   );
   expect(results.token).toBe("foobarabc123");
+});
+
+test("it should quote the native Windows npm.cmd fallback command line", async () => {
+  mockedPlatform = "win32";
+  vi.mocked(utils.isWsl).mockReturnValue(false);
+  vi.mocked(spawnSync).mockReturnValue({
+    status: 0,
+    stdout: '{ "token": "foobarabc123" }',
+    stderr: "",
+  } as any);
+
+  await adoPat({
+    promptHint: "hint with spaces",
+    organization: "org",
+    displayName: "test display",
+    scope: ["foobar"],
+    output: "json",
+  });
+
+  expect(spawnSync).toHaveBeenCalledWith(
+    expect.stringContaining('"hint with spaces"'),
+    expect.objectContaining({ shell: true }),
+  );
+});
+
+test("it should surface spawnSync launch failures", async () => {
+  vi.mocked(utils.isWsl).mockReturnValue(false);
+  vi.mocked(spawnSync).mockReturnValue({
+    status: null,
+    stdout: "",
+    stderr: "",
+    error: new Error("spawn ENOENT"),
+  } as any);
+
+  await expect(
+    adoPat({
+      promptHint: "hint",
+      organization: "org",
+      displayName: "test display",
+      scope: ["foobar"],
+      output: "json",
+    }),
+  ).rejects.toThrowError("Failed to get Ado Pat from AzureAuth: spawn ENOENT");
 });
 
 test("it should spawnSync azureauth on wsl", async () => {
   vi.mocked(spawnSync).mockReturnValue({
     status: 0,
     stdout: '{ "token": "foobarabc123" }',
+    stderr: "",
   } as any);
   vi.mocked(utils.isWsl).mockReturnValue(true);
 
@@ -86,24 +157,26 @@ test("it should spawnSync azureauth on wsl", async () => {
   })) as AdoPatResponse;
 
   expect(spawnSync).toHaveBeenCalledWith(
-    "npm",
+    "azureauth.exe",
     [
-      "exec",
-      "--silent",
-      "--yes",
-      "azureauth",
-      "--",
       "ado",
       "pat",
-      "--prompt-hint hint",
-      "--organization org",
-      "--display-name test display",
-      "--scope foobar",
-      "--output json",
-      "--domain baz.com",
-      "--timeout 200",
+      "--prompt-hint",
+      "hint",
+      "--organization",
+      "org",
+      "--display-name",
+      "test display",
+      "--scope",
+      "foobar",
+      "--output",
+      "json",
+      "--domain",
+      "baz.com",
+      "--timeout",
+      "200",
     ],
-    expect.anything(),
+    expect.objectContaining({ shell: false }),
   );
   expect(results.token).toBe("foobarabc123");
 });
@@ -127,7 +200,7 @@ test("it should handle errors on wsl if azureauth exit code is not 0", async () 
       timeout: "200",
     }),
   ).rejects.toThrowError(
-    "Failed to get Ado Pat from system AzureAuth: Azure Auth failed with exit code 1: an error",
+    "Failed to get Ado Pat from AzureAuth: Azure Auth failed with exit code 1: an error",
   );
 });
 
@@ -150,18 +223,17 @@ test("it should handle errors on wsl if azureauth has stderr output", async () =
       timeout: "200",
     }),
   ).rejects.toThrowError(
-    "Failed to get Ado Pat from system AzureAuth: Azure Auth failed with exit code 0: an error",
+    "Failed to get Ado Pat from AzureAuth: Azure Auth failed with exit code 0: an error",
   );
 });
 
 test("it should handle json errors", async () => {
   vi.mocked(utils.isWsl).mockReturnValue(false);
-  vi.mocked(exec).mockReturnValue(
-    Promise.resolve({
-      stdout: "an error",
-      stderr: "",
-    }) as any,
-  );
+  vi.mocked(spawnSync).mockReturnValue({
+    status: 0,
+    stdout: "an error",
+    stderr: "",
+  } as any);
 
   await expect(
     adoPat({
@@ -176,14 +248,100 @@ test("it should handle json errors", async () => {
   ).rejects.toThrowError("Failed to parse JSON output: an error");
 });
 
+test("it should forward --tenant when options.tenant is set", async () => {
+  vi.mocked(utils.isWsl).mockReturnValue(false);
+  vi.mocked(spawnSync).mockReturnValue({
+    status: 0,
+    stdout: '{ "token": "foobarabc123" }',
+    stderr: "",
+  } as any);
+
+  await adoPat({
+    promptHint: "hint",
+    organization: "org",
+    displayName: "test display",
+    scope: ["foobar"],
+    output: "json",
+    tenant: "00000000-0000-0000-0000-000000000001",
+    domain: "contoso.com",
+    timeout: "200",
+  });
+
+  const [, calledArgs] = vi.mocked(spawnSync).mock.calls[0];
+  const tenantIdx = (calledArgs as string[]).indexOf("--tenant");
+  expect(tenantIdx).toBeGreaterThanOrEqual(0);
+  expect((calledArgs as string[])[tenantIdx + 1]).toBe(
+    "00000000-0000-0000-0000-000000000001",
+  );
+  const domainIdx = (calledArgs as string[]).indexOf("--domain");
+  expect(domainIdx).toBeGreaterThanOrEqual(0);
+  expect((calledArgs as string[])[domainIdx + 1]).toBe("contoso.com");
+});
+
+test("it should omit --tenant when options.tenant is unset", async () => {
+  vi.mocked(utils.isWsl).mockReturnValue(false);
+  vi.mocked(spawnSync).mockReturnValue({
+    status: 0,
+    stdout: '{ "token": "foobarabc123" }',
+    stderr: "",
+  } as any);
+
+  await adoPat({
+    promptHint: "hint",
+    organization: "org",
+    displayName: "test display",
+    scope: ["foobar"],
+    output: "json",
+    timeout: "200",
+  });
+
+  const [, calledArgs] = vi.mocked(spawnSync).mock.calls[0];
+  expect(calledArgs).not.toContain("--tenant");
+});
+
+test("it should pass shell metacharacters in tenant/domain verbatim without shell interpretation", async () => {
+  vi.mocked(utils.isWsl).mockReturnValue(false);
+  vi.mocked(spawnSync).mockReturnValue({
+    status: 0,
+    stdout: '{ "token": "safe" }',
+    stderr: "",
+  } as any);
+
+  const maliciousTenant = "abc$(touch /tmp/pwned)";
+  const maliciousDomain = "evil;rm -rf /";
+
+  await adoPat({
+    promptHint: "hint",
+    organization: "org",
+    displayName: "test display",
+    scope: ["foobar"],
+    output: "json",
+    tenant: maliciousTenant,
+    domain: maliciousDomain,
+  });
+
+  const [launcher, calledArgs, opts] = vi.mocked(spawnSync).mock.calls[0];
+  expect(launcher).toBe(expectedLauncher());
+
+  const argv = calledArgs as string[];
+  const tenantIdx = argv.indexOf("--tenant");
+  expect(tenantIdx).toBeGreaterThanOrEqual(0);
+  expect(argv[tenantIdx + 1]).toBe(maliciousTenant);
+
+  const domainIdx = argv.indexOf("--domain");
+  expect(domainIdx).toBeGreaterThanOrEqual(0);
+  expect(argv[domainIdx + 1]).toBe(maliciousDomain);
+
+  expect(opts).toEqual(expect.objectContaining({ shell: false }));
+});
+
 test("it should handle errors from azureauth-cli", async () => {
   vi.mocked(utils.isWsl).mockReturnValue(false);
-  vi.mocked(exec).mockReturnValue(
-    Promise.resolve({
-      stdout: "",
-      stderr: "an error",
-    }) as any,
-  );
+  vi.mocked(spawnSync).mockReturnValue({
+    status: 0,
+    stdout: "",
+    stderr: "an error",
+  } as any);
 
   await expect(
     adoPat({
@@ -195,5 +353,7 @@ test("it should handle errors from azureauth-cli", async () => {
       domain: "baz.com",
       timeout: "200",
     }),
-  ).rejects.toThrowError("Failed to get Ado Pat from npx AzureAuth: an error");
+  ).rejects.toThrowError(
+    "Failed to get Ado Pat from AzureAuth: Azure Auth failed with exit code 0: an error",
+  );
 });

--- a/packages/ado-npm-auth-lib/src/azureauth/ado.ts
+++ b/packages/ado-npm-auth-lib/src/azureauth/ado.ts
@@ -1,9 +1,7 @@
 import { arch, platform } from "node:os";
 import { spawnSync } from "node:child_process";
-import { exec } from "../utils/exec.js";
 import { isSupportedPlatformAndArchitecture } from "./is-supported-platform-and-architecture.js";
 import { azureAuthCommand } from "./azureauth-command.js";
-import { isWsl } from "../utils/is-wsl.js";
 import { isAzureAuthInstalled } from "./is-azureauth-installed.js";
 
 export type AdoPatOptions = {
@@ -14,6 +12,7 @@ export type AdoPatOptions = {
   output?: string;
   mode?: string;
   domain?: string;
+  tenant?: string;
   timeout?: string;
 };
 
@@ -27,6 +26,17 @@ export type AdoPatResponse = {
   token: string;
 };
 
+const quoteWindowsShellArg = (arg: string): string => {
+  if (arg.length === 0) {
+    return '""';
+  }
+
+  return `"${arg.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\+)$/g, "$1$1")}"`;
+};
+
+const buildWindowsShellCommand = (executable: string, args: string[]): string =>
+  [executable, ...args].map(quoteWindowsShellArg).join(" ");
+
 /**
  * Wrapper for `azureauth ado pat`. Please run `azureauth ado pat --help` for full command options and description
  * @param options Options for PAT generation
@@ -36,9 +46,11 @@ export const adoPat = async (
   options: AdoPatOptions,
   azureAuthLocation?: string,
 ): Promise<AdoPatResponse | string> => {
+  const currentPlatform = platform();
+
   if (!isSupportedPlatformAndArchitecture()) {
     throw new Error(
-      `AzureAuth is not supported for platform ${platform()} and architecture ${arch()}`,
+      `AzureAuth is not supported for platform ${currentPlatform} and architecture ${arch()}`,
     );
   }
 
@@ -49,60 +61,72 @@ export const adoPat = async (
       }
     : azureAuthCommand();
 
-  const command = [
+  const argv: string[] = [
     ...authCommand,
-    `ado`,
-    `pat`,
-    `--prompt-hint ${isWsl() ? options.promptHint : `"${options.promptHint}"`}`, // We only use spawn for WSL. spawn does not does not require prompt hint to be wrapped in quotes. exec does.
-    `--organization ${options.organization}`,
-    `--display-name ${options.displayName}`,
-    ...options.scope.map((scope) => `--scope ${scope}`),
+    "ado",
+    "pat",
+    "--prompt-hint",
+    options.promptHint,
+    "--organization",
+    options.organization,
+    "--display-name",
+    options.displayName,
+    ...options.scope.flatMap((s) => ["--scope", s]),
   ];
 
   if (options.output) {
-    command.push(`--output ${options.output}`);
+    argv.push("--output", options.output);
   }
-
   if (options.mode) {
-    command.push(`--mode ${options.mode}`);
+    argv.push("--mode", options.mode);
   }
-
+  if (options.tenant) {
+    argv.push("--tenant", options.tenant);
+  }
   if (options.domain) {
-    command.push(`--domain ${options.domain}`);
+    argv.push("--domain", options.domain);
+  }
+  if (options.timeout) {
+    argv.push("--timeout", options.timeout);
   }
 
-  if (options.timeout) {
-    command.push(`--timeout ${options.timeout}`);
+  let executable = argv[0];
+  if (currentPlatform === "win32" && executable === "npm") {
+    executable = "npm.cmd";
   }
+  const args = argv.slice(1);
+  const requiresShell = currentPlatform === "win32" && /\.(cmd|bat)$/i.test(executable);
+
+  const wrapperMessage = "Failed to get Ado Pat from AzureAuth";
 
   try {
     let result;
-    if (isWsl()) {
-      try {
-        result = spawnSync(command[0], command.slice(1), { encoding: "utf-8" });
+    try {
+      // The Windows shell fallback only applies to the internally constructed
+      // `npm.cmd` launcher path. Keep the argv-based path everywhere else.
+      result = requiresShell
+        ? spawnSync(buildWindowsShellCommand(executable, args), {
+            encoding: "utf-8",
+            env,
+            shell: true,
+          })
+        : spawnSync(executable, args, {
+            encoding: "utf-8",
+            env,
+            shell: false,
+          });
 
-        if (result.status !== 0 || (result.stderr && !result.stdout)) {
-          throw new Error(
-            `Azure Auth failed with exit code ${result.status}: ${result.stderr}`,
-          );
-        }
-      } catch (error: any) {
+      if (result.error) {
+        throw result.error;
+      }
+
+      if (result.status !== 0 || (result.stderr && !result.stdout)) {
         throw new Error(
-          `Failed to get Ado Pat from system AzureAuth: ${error.message}`,
+          `Azure Auth failed with exit code ${result.status}: ${result.stderr}`,
         );
       }
-    } else {
-      try {
-        result = await exec(command.join(" "), { env });
-
-        if (result.stderr && !result.stdout) {
-          throw new Error(result.stderr);
-        }
-      } catch (error: any) {
-        throw new Error(
-          `Failed to get Ado Pat from npx AzureAuth: ${error.message}`,
-        );
-      }
+    } catch (error: any) {
+      throw new Error(`${wrapperMessage}: ${error.message}`);
     }
 
     if (options.output === "json") {

--- a/packages/ado-npm-auth-lib/src/azureauth/azureauth-command.ts
+++ b/packages/ado-npm-auth-lib/src/azureauth/azureauth-command.ts
@@ -2,6 +2,7 @@ import { isWsl } from "../utils/is-wsl.js";
 
 let memo: string[] | undefined = undefined;
 
+/** @internal Test-only helper for resetting memoized command detection. */
 export const clearMemo = () => {
   memo = void 0;
 };

--- a/packages/ado-npm-auth-lib/src/index.ts
+++ b/packages/ado-npm-auth-lib/src/index.ts
@@ -5,6 +5,7 @@ export { NpmrcFileProvider } from "./npmrc/npmrcFileProvider.js";
 export type { Feed, ValidatedFeed } from "./fileProvider.js";
 export { defaultUser, defaultEmail, FileProvider } from "./fileProvider.js";
 
+export type { GenerateNpmrcPatOptions } from "./npmrc/generate-npmrc-pat.js";
 export { generateNpmrcPat } from "./npmrc/generate-npmrc-pat.js";
 
 export { getOrganizationFromFeedUrl } from "./utils/get-organization-from-feed-url.js";

--- a/packages/ado-npm-auth-lib/src/npmrc/generate-npmrc-pat.test.ts
+++ b/packages/ado-npm-auth-lib/src/npmrc/generate-npmrc-pat.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import * as ado from "../azureauth/ado.js";
+import * as wsl from "../utils/is-wsl.js";
+import { generateNpmrcPat } from "./generate-npmrc-pat.js";
+import * as nuget from "./nugetCredentialProvider.js";
+
+vi.mock("../azureauth/ado.js", async () => {
+  return {
+    adoPat: vi.fn(),
+  };
+});
+
+vi.mock("./nugetCredentialProvider.js", async () => {
+  return {
+    credentialProviderPat: vi.fn(),
+  };
+});
+
+vi.mock("../utils/is-wsl.js", async () => {
+  return {
+    isWsl: vi.fn(() => false),
+  };
+});
+
+let mockedPlatform: NodeJS.Platform = "darwin";
+
+vi.mock("node:os", async () => {
+  const actual = await vi.importActual<typeof import("node:os")>("node:os");
+  return {
+    ...actual,
+    hostname: () => "test-host",
+    platform: () => mockedPlatform,
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedPlatform = "darwin";
+  vi.mocked(wsl.isWsl).mockReturnValue(false);
+});
+
+test("forwards tenant and domain options to adoPat", async () => {
+  vi.mocked(ado.adoPat).mockResolvedValue({ token: "abc" } as any);
+
+  await generateNpmrcPat("myorg", "https://feed.example", false, undefined, {
+    tenant: "00000000-0000-0000-0000-000000000001",
+    domain: "contoso.com",
+  });
+
+  expect(ado.adoPat).toHaveBeenCalledWith(
+    expect.objectContaining({
+      organization: "myorg",
+      tenant: "00000000-0000-0000-0000-000000000001",
+      domain: "contoso.com",
+    }),
+    undefined,
+  );
+});
+
+test("passes undefined tenant/domain when options are omitted", async () => {
+  vi.mocked(ado.adoPat).mockResolvedValue({ token: "abc" } as any);
+
+  await generateNpmrcPat("myorg", "https://feed.example");
+
+  expect(ado.adoPat).toHaveBeenCalledWith(
+    expect.objectContaining({
+      organization: "myorg",
+      tenant: undefined,
+      domain: undefined,
+    }),
+    undefined,
+  );
+});
+
+test("uses the credential provider on linux when tenant/domain overrides are unset", async () => {
+  mockedPlatform = "linux";
+  vi.mocked(nuget.credentialProviderPat).mockResolvedValue({
+    Username: "user",
+    Password: "cp-token",
+  });
+
+  const token = await generateNpmrcPat("myorg", "https://feed.example");
+
+  expect(token).toBe("cp-token");
+  expect(nuget.credentialProviderPat).toHaveBeenCalledWith(
+    "https://feed.example",
+  );
+  expect(ado.adoPat).not.toHaveBeenCalled();
+});
+
+test("throws on linux when tenant/domain overrides are set", async () => {
+  mockedPlatform = "linux";
+
+  await expect(
+    generateNpmrcPat("myorg", "https://feed.example", false, undefined, {
+      tenant: "00000000-0000-0000-0000-000000000001",
+      domain: "contoso.com",
+    }),
+  ).rejects.toThrow(
+    "tenant/domain overrides are not supported on Linux with CredentialProvider.Microsoft",
+  );
+
+  expect(nuget.credentialProviderPat).not.toHaveBeenCalled();
+  expect(ado.adoPat).not.toHaveBeenCalled();
+});
+
+test("routes WSL through azureauth and forwards tenant/domain", async () => {
+  mockedPlatform = "linux";
+  vi.mocked(wsl.isWsl).mockReturnValue(true);
+  vi.mocked(ado.adoPat).mockResolvedValue({ token: "wsl-token" } as any);
+
+  const token = await generateNpmrcPat(
+    "myorg",
+    "https://feed.example",
+    false,
+    undefined,
+    {
+      tenant: "00000000-0000-0000-0000-000000000001",
+      domain: "contoso.com",
+    },
+  );
+
+  expect(token).toBe("wsl-token");
+  expect(ado.adoPat).toHaveBeenCalledWith(
+    expect.objectContaining({
+      organization: "myorg",
+      tenant: "00000000-0000-0000-0000-000000000001",
+      domain: "contoso.com",
+    }),
+    undefined,
+  );
+  expect(nuget.credentialProviderPat).not.toHaveBeenCalled();
+});

--- a/packages/ado-npm-auth-lib/src/npmrc/generate-npmrc-pat.ts
+++ b/packages/ado-npm-auth-lib/src/npmrc/generate-npmrc-pat.ts
@@ -2,7 +2,21 @@ import { hostname, platform } from "node:os";
 import type { AdoPatResponse } from "../azureauth/ado.js";
 import { adoPat } from "../azureauth/ado.js";
 import { toBase64 } from "../utils/encoding.js";
+import { isWsl } from "../utils/is-wsl.js";
 import { credentialProviderPat } from "./nugetCredentialProvider.js";
+
+/**
+ * Optional overrides forwarded to `azureauth ado pat`.
+ *
+ * - `tenant`: Azure AD tenant ID. When unset, azureauth defaults to the
+ *   Microsoft tenant, which fails for non-Microsoft corporate tenants.
+ * - `domain`: preferred account domain used to filter cached MSAL accounts
+ *   (e.g. "contoso.com"). Useful when multiple tenants share the MSAL cache.
+ */
+export type GenerateNpmrcPatOptions = {
+  tenant?: string;
+  domain?: string;
+};
 
 /**
  * Generates a valid ADO PAT, scoped for vso.packaging in the given ado organization, 30 minute timeout
@@ -13,6 +27,7 @@ export const generateNpmrcPat = async (
   feed: string,
   encode = false,
   azureAuthLocation?: string,
+  options: GenerateNpmrcPatOptions = {},
 ): Promise<string> => {
   const name = `${hostname()}-${organization}`;
   const rawToken = await getRawToken(
@@ -20,6 +35,7 @@ export const generateNpmrcPat = async (
     organization,
     feed,
     azureAuthLocation,
+    options,
   );
 
   if (encode) {
@@ -34,7 +50,11 @@ async function getRawToken(
   organization: string,
   feed: string,
   azureAuthLocation?: string,
+  options: GenerateNpmrcPatOptions = {},
 ): Promise<string> {
+  const linuxTenantDomainOverrideError =
+    "tenant/domain overrides are not supported on Linux with CredentialProvider.Microsoft";
+
   /**
    *  Use vso.packaging_write to include "Collaborator" (Feed and Upstream Reader) permissions.
    * vso.packaging only provides "Reader" access (view/download packages).
@@ -45,24 +65,37 @@ async function getRawToken(
    * I filed feedback on VSO to add this: https://developercommunity.visualstudio.com/t/the-scope-for-vsopackaging-SHOULD-inclu/10998135
    */
   const patScope = "vso.packaging_write";
+  const getAzureAuthToken = async (): Promise<string> => {
+    const pat = await adoPat(
+      {
+        promptHint: `Authenticate to ${organization} to generate a temporary token for npm`,
+        organization,
+        displayName: name,
+        scope: [patScope],
+        tenant: options.tenant,
+        domain: options.domain,
+        timeout: "30",
+        output: "json",
+      },
+      azureAuthLocation,
+    );
+
+    return (pat as AdoPatResponse).token;
+  };
+
+  if (isWsl()) {
+    return await getAzureAuthToken();
+  }
 
   switch (platform()) {
     case "win32":
-    case "darwin": {
-      const pat = await adoPat(
-        {
-          promptHint: `Authenticate to ${organization} to generate a temporary token for npm`,
-          organization,
-          displayName: name,
-          scope: [patScope],
-          timeout: "30",
-          output: "json",
-        },
-        azureAuthLocation,
-      );
-      return (pat as AdoPatResponse).token;
-    }
+    case "darwin":
+      return await getAzureAuthToken();
     case "linux": {
+      if (options.tenant || options.domain) {
+        throw new Error(linuxTenantDomainOverrideError);
+      }
+
       const cpPat = await credentialProviderPat(feed);
       return cpPat.Password;
     }

--- a/packages/yarn-plugin-ado-auth/README.md
+++ b/packages/yarn-plugin-ado-auth/README.md
@@ -30,7 +30,7 @@ yarn plugin import /path/to/yarn-plugin-ado-auth/dist/yarn-plugin-ado-auth.cjs
 
 ## Configuration
 
-The plugin supports two configuration options in your `.yarnrc.yml` file:
+The plugin supports the following configuration options in your `.yarnrc.yml` file:
 
 ### `adoNpmAuthFeedPrefix`
 
@@ -52,6 +52,32 @@ The absolute path to the `azureauth` CLI tool. If not specified, the plugin will
 
 ```yaml
 adoNpmAuthToolPath: "/usr/local/bin/azureauth"
+```
+
+### `adoNpmAuthTenantId`
+
+**Type:** `string` (optional)
+**Default:** `null` (azureauth defaults to the Microsoft tenant)
+
+The Azure AD tenant ID forwarded to `azureauth ado pat --tenant <id>`. When unset, `azureauth` targets the Microsoft tenant (`72f988bf-86f1-41af-91ab-2d7cd011db47`), which is correct for Microsoft employees but fails for any other corporate tenant using Azure DevOps Artifacts. Set this to your own tenant ID to authenticate against your organization's Azure DevOps.
+
+This override is supported when the plugin authenticates through `azureauth` directly: Windows, macOS, and WSL. Native Linux continues to use `CredentialProvider.Microsoft`, so this setting is not supported there.
+
+```yaml
+adoNpmAuthTenantId: "00000000-0000-0000-0000-000000000000"
+```
+
+### `adoNpmAuthDomain`
+
+**Type:** `string` (optional)
+**Default:** `null` (azureauth defaults to `microsoft.com`)
+
+The preferred account domain forwarded to `azureauth ado pat --domain <domain>`. Used to filter cached MSAL accounts when the same machine has signed-in accounts in multiple tenants (for example, a home account in your corporate tenant plus guest access in the Microsoft tenant). Set this to your own email domain to make `azureauth` prefer the right cached account.
+
+As with `adoNpmAuthTenantId`, this override is only supported on Windows, macOS, and WSL. Native Linux does not support this setting.
+
+```yaml
+adoNpmAuthDomain: "contoso.com"
 ```
 
 ## The azureauth Command Line Tool
@@ -184,6 +210,8 @@ plugins:
 # ADO Auth Plugin Settings
 adoNpmAuthFeedPrefix: "https://pkgs.dev.azure.com/"
 adoNpmAuthToolPath: null # Use azureauth from PATH
+adoNpmAuthTenantId: "00000000-0000-0000-0000-000000000000" # Your Azure AD tenant ID
+adoNpmAuthDomain: "contoso.com" # Your corporate email domain
 
 # Registry Configuration
 npmScopes:
@@ -227,6 +255,21 @@ Here's what happens when you run `yarn install`:
 - Ensure the `ADO_NPM_TOKEN` (or your chosen environment variable) is set in your pipeline
 - Verify the token has appropriate permissions for the ADO feed
 - Check that the token hasn't expired (ADO PATs have configurable expiration dates)
+
+### `VS30063: You are not authorized to access https://dev.azure.com`
+
+This error surfaces when `azureauth` obtains a token against the wrong tenant. The most common case: your Azure DevOps organization lives in a non-Microsoft tenant, but `azureauth` defaults to the Microsoft tenant and grabs a cached guest account that has no access to your org.
+
+Fix it by setting both `adoNpmAuthTenantId` and `adoNpmAuthDomain` in `.yarnrc.yml` on Windows, macOS, or WSL:
+
+```yaml
+adoNpmAuthTenantId: "<your-tenant-id>"
+adoNpmAuthDomain: "<your-email-domain>"
+```
+
+Find your tenant ID in the Azure portal under **Microsoft Entra ID → Overview → Tenant ID**.
+
+On native Linux, these overrides are not supported because the plugin uses `CredentialProvider.Microsoft` instead of `azureauth`.
 
 ### Token caching issues
 

--- a/packages/yarn-plugin-ado-auth/src/configuration.ts
+++ b/packages/yarn-plugin-ado-auth/src/configuration.ts
@@ -4,6 +4,8 @@ import { getConfigString } from "./utils.ts";
 export type AuthPluginConfigurationValueMap = {
   adoNpmAuthToolPath?: string;
   adoNpmAuthFeedPrefix: string;
+  adoNpmAuthTenantId?: string;
+  adoNpmAuthDomain?: string;
 };
 
 export function getConfiguration() {
@@ -18,6 +20,16 @@ export function getConfiguration() {
       type: SettingsType.STRING,
       default: `https://pkgs.dev.azure.com/`,
     },
+    adoNpmAuthTenantId: {
+      description: `The Azure AD tenant ID to use when authenticating with Azure DevOps. If unset, azureauth defaults to the Microsoft tenant, which fails for non-Microsoft corporate tenants.`,
+      type: SettingsType.STRING,
+      default: null,
+    },
+    adoNpmAuthDomain: {
+      description: `The preferred account domain for filtering cached MSAL accounts (e.g. "contoso.com"). Useful when the user has cached accounts in multiple tenants.`,
+      type: SettingsType.STRING,
+      default: null,
+    },
   } as Plugin["configuration"];
 }
 
@@ -31,5 +43,7 @@ export function loadConfiguration(
       "adoNpmAuthFeedPrefix",
       true,
     ),
+    adoNpmAuthTenantId: getConfigString(configuration, "adoNpmAuthTenantId"),
+    adoNpmAuthDomain: getConfigString(configuration, "adoNpmAuthDomain"),
   };
 }

--- a/packages/yarn-plugin-ado-auth/src/tokenCache.ts
+++ b/packages/yarn-plugin-ado-auth/src/tokenCache.ts
@@ -21,6 +21,8 @@ export class TokenCache {
   private configuration: Configuration;
   private prefix: string;
   private azureAuthPath?: string;
+  private tenantId?: string;
+  private domain?: string;
   private cache: Record<string, string | Promise<string>> = {};
 
   constructor(
@@ -31,6 +33,8 @@ export class TokenCache {
     const settings = loadConfig(configuration);
     this.prefix = settings.adoNpmAuthFeedPrefix ?? "";
     this.azureAuthPath = settings.adoNpmAuthToolPath || findAzureAuthPath();
+    this.tenantId = settings.adoNpmAuthTenantId;
+    this.domain = settings.adoNpmAuthDomain;
   }
 
   /**
@@ -90,6 +94,7 @@ export class TokenCache {
           registry,
           false,
           this.azureAuthPath,
+          { tenant: this.tenantId, domain: this.domain },
         );
         this.cache[registry] = pat;
         report.reportInfo(


### PR DESCRIPTION
Closes #138.

## Summary

- Adds `adoNpmAuthTenantId` and `adoNpmAuthDomain` options in `.yarnrc.yml`, forwarded as `--tenant` / `--domain` to `azureauth ado pat`. Unblocks ADO organizations that live in a non-Microsoft Azure AD tenant (today `azureauth` defaults to the Microsoft tenant, so non-MS users hit `VS30063: You are not authorized to access https://dev.azure.com` — see #138).
- Hardens `adoPat` execution: replaces `exec(<shell string>)` with `spawnSync(argv, { shell: false })` on all platforms. Windows `npm.cmd` launcher still uses `shell: true` via an explicit `buildWindowsShellCommand` helper that quotes arguments per the MSVCRT convention. Removes the separate WSL branch — WSL now falls into the argv-based path with `azureauth.exe` directly.
- Routes WSL through `azureauth` (via `isWsl()` guard in `getRawToken`) so the new tenant/domain overrides actually work there; native Linux keeps using `CredentialProvider.Microsoft` and rejects tenant/domain with a clear error.
- Documents the new config options, the `VS30063` troubleshooting flow, and the supported-platform matrix in `packages/yarn-plugin-ado-auth/README.md`.

## Test plan

- [x] `yarn vitest run` in `packages/ado-npm-auth-lib` — 59/59 pass, including new tests:
  - `ado.test.ts`: `--tenant` / `--domain` forwarding, argv-based shell-metacharacter safety, Windows `npm.cmd` shell-quoting path, WSL path.
  - `generate-npmrc-pat.test.ts`: tenant/domain forwarding on darwin, linux guard throws, WSL routes through `azureauth` with tenant/domain forwarded.
- [ ] Manual: `yarn install` against an ADO feed in a non-Microsoft tenant with `adoNpmAuthTenantId` + `adoNpmAuthDomain` set, on macOS / Windows / WSL.
- [ ] Manual: `yarn install` on native Linux without overrides (CredentialProvider.Microsoft path) — unchanged behavior.