### PR TITLE
Update AzureAuth to 0.9.6 for macOS broker support

### DIFF
--- a/change/change-6b89fde4-d7d4-4203-a8c5-58d91ddb7467.json
+++ b/change/change-6b89fde4-d7d4-4203-a8c5-58d91ddb7467.json
@@ -1,0 +1,18 @@
+{
+  "changes": [
+    {
+      "type": "minor",
+      "comment": "Update AzureAuth for macOS broker support",
+      "packageName": "ado-npm-auth",
+      "email": "kyle@rubenok.ca",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "minor",
+      "comment": "Update AzureAuth for macOS broker support",
+      "packageName": "@microsoft/yarn-plugin-ado-auth",
+      "email": "kyle@rubenok.ca",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/change/change-8448867a-b855-4fab-8f47-b281751d3657.json
+++ b/change/change-8448867a-b855-4fab-8f47-b281751d3657.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Update AzureAuth to 0.9.6 for macOS broker auth",
+      "packageName": "azureauth",
+      "email": "kyle@rubenok.ca",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/ado-npm-auth/README.md
+++ b/packages/ado-npm-auth/README.md
@@ -22,6 +22,12 @@ The main difference between the two is how they function, and where they can run
 
 Since the `azureauth-cli` is cross-platform, `ado-npm-auth` will also run cross-platform as well!
 
+On macOS, the bundled `azureauth` CLI supports brokered authentication through the Microsoft Enterprise SSO Extension. Broker auth is opt-in; set `AZUREAUTH_MODE=broker` before running `ado-npm-auth` to use it.
+
+```bash
+AZUREAUTH_MODE=broker npm exec ado-npm-auth
+```
+
 One of the easiest ways to use the tool is to add it to your `"preinstall"` script in your repo like this...
 
 ```json
@@ -36,12 +42,14 @@ It will then perform a quick "pre-flight" check to assess if the token is valid,
 
 ### Beware the chicken and egg problem
 
-You may need to set the registry to the public NPM feed when running `npm exec` or `npx`. 
+You may need to set the registry to the public NPM feed when running `npm exec` or `npx`.
 
 There are 2 options to address this case:
 
 ### 1: Explictly pass the config file.
+
 You can hop one directory up, or run it from an arbitrary path and pass the configuration.
+
 ```cmd
 pushd ..
 npx ado-npm-auth -c <myrepo>\.npmrc
@@ -49,9 +57,10 @@ popd
 ```
 
 ### 2: configure registry explicilty
-If that's the case, set the environment variable `npm_config_registry=https://registry.npmjs.org`. 
 
-That will ensure that `npx` or `npm exec` grabs from the public NPM feed, bypassing the soon-to-be authenticated ADO feed. 
+If that's the case, set the environment variable `npm_config_registry=https://registry.npmjs.org`.
+
+That will ensure that `npx` or `npm exec` grabs from the public NPM feed, bypassing the soon-to-be authenticated ADO feed.
 
 ```json
 "scripts": {

--- a/packages/node-azureauth/README.md
+++ b/packages/node-azureauth/README.md
@@ -25,6 +25,14 @@ Use the `azureauth` CLI by calling it from NPM scripts.
 > npm run authcli
 ```
 
+On macOS, AzureAuth supports brokered authentication through the Microsoft Enterprise SSO Extension. Broker auth is opt-in; pass `--mode broker` to the `azureauth` command when you want to use it.
+
+```json
+"scripts": {
+  "authcli": "azureauth ado pat --mode broker"
+}
+```
+
 Use it as a node module by importing azureauth.
 
 ```js
@@ -35,5 +43,6 @@ const pat = await adoPat({
   organization: "test",
   promptHint: "test",
   scope: ["test"],
+  mode: "broker",
 });
 ```

--- a/packages/node-azureauth/src/install.ts
+++ b/packages/node-azureauth/src/install.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import { DownloaderHelper } from "node-downloader-helper";
 import decompress from "decompress";
 
-const AZURE_AUTH_VERSION = "0.8.4";
+const AZURE_AUTH_VERSION = "0.9.6";
 
 async function download(url: string, saveDirectory: string): Promise<void> {
   const downloader = new DownloaderHelper(url, saveDirectory);
@@ -29,7 +29,8 @@ const AZUREAUTH_INFO = {
   name: "azureauth",
   // https://github.com/AzureAD/microsoft-authentication-cli/releases/download/${AZUREAUTH_INFO.version}/azureauth-${AZUREAUTH_INFO.version}-osx-arm64.tar.gz
   // https://github.com/AzureAD/microsoft-authentication-cli/releases/download/${AZUREAUTH_INFO.version}/azureauth-${AZUREAUTH_INFO.version}-osx-x64.tar.gz
-  // https://github.com/AzureAD/microsoft-authentication-cli/releases/download/${AZUREAUTH_INFO.version}/azureauth-${AZUREAUTH_INFO.version}-win10-x64.zip
+  // https://github.com/AzureAD/microsoft-authentication-cli/releases/download/${AZUREAUTH_INFO.version}/azureauth-${AZUREAUTH_INFO.version}-win-arm64.zip
+  // https://github.com/AzureAD/microsoft-authentication-cli/releases/download/${AZUREAUTH_INFO.version}/azureauth-${AZUREAUTH_INFO.version}-win-x64.zip
   url: "https://github.com/AzureAD/microsoft-authentication-cli/releases/download/",
   version: AZURE_AUTH_VERSION,
 };
@@ -67,16 +68,17 @@ export const install = async () => {
   // if platform is missing, download source instead of executable
   const DOWNLOAD_MAP: any = {
     win32: {
-      x64: `azureauth-${AZUREAUTH_INFO.version}-win10-x64.zip`,
+      arm64: `azureauth-${AZUREAUTH_INFO.version}-win-arm64.zip`,
+      x64: `azureauth-${AZUREAUTH_INFO.version}-win-x64.zip`,
     },
     darwin: {
       x64: `azureauth-${AZUREAUTH_INFO.version}-osx-x64.tar.gz`,
       arm64: `azureauth-${AZUREAUTH_INFO.version}-osx-arm64.tar.gz`,
     },
-    // TODO: support linux when the binaries are available
+    // TODO: support installing linux .deb packages
     // linux: {
-    //   def: "azureauth.exe",
-    //   x64: "azureauth-${AZUREAUTH_INFO.version}-win10-x64.zip",
+    //   x64: `azureauth-${AZUREAUTH_INFO.version}-linux-x64.deb`,
+    //   arm64: `azureauth-${AZUREAUTH_INFO.version}-linux-arm64.deb`,
     // },
   };
   if (platform in DOWNLOAD_MAP) {

--- a/packages/yarn-plugin-ado-auth/README.md
+++ b/packages/yarn-plugin-ado-auth/README.md
@@ -87,6 +87,12 @@ When authentication is needed, the plugin executes the `azureauth` CLI with para
 
 The `azureauth` tool supports multiple platforms (Windows, macOS, Linux) and architectures (x64, ARM64).
 
+On macOS, AzureAuth supports brokered authentication through the Microsoft Enterprise SSO Extension. Broker auth is opt-in; set `AZUREAUTH_MODE=broker` before running Yarn to use it.
+
+```bash
+AZUREAUTH_MODE=broker yarn install
+```
+
 ## Using npmAuthToken in .yarnrc.yml
 
 The plugin respects Yarn's standard npm authentication configuration. You can pre-configure tokens in your `.yarnrc.yml` file, and the plugin will use them instead of triggering authentication.


### PR DESCRIPTION
## Summary

- Update the bundled AzureAuth CLI from 0.8.4 to 0.9.6.
- Update AzureAuth release artifact names for the current Windows packages, including win-arm64.
- Document the macOS broker opt-in path for azureauth, ado-npm-auth, and the Yarn plugin.

## Draft status / blocker

This is intentionally a draft. AzureAuth 0.9.6 contains macOS broker support, but local validation shows the Azure DevOps PAT path does not work yet with the built-in ADO client registration.

The failing path is:

```bash
node packages/node-azureauth/scripts/azureauth.cjs ado pat \
  --mode broker \
  --organization outlookweb \
  --display-name local-macos-broker-test \
  --prompt-hint "Authenticate to outlookweb for local macOS broker test" \
  --scope vso.packaging_write \
  --output json \
  --timeout 30 \
  --verbosity debug
```

That fails in broker token acquisition with WAM error `-51411`, `ApiContractViolation`, and AADSTS50011. The narrower AAD repro using AzureAuth's built-in Azure DevOps parameters also fails with the same `51411` error:

```bash
node packages/node-azureauth/scripts/azureauth.cjs aad \
  --client 872cd9fa-d31f-45e0-9eab-6e460a02d1f1 \
  --tenant 72f988bf-86f1-41af-91ab-2d7cd011db47 \
  --scope 499b84ac-1321-427f-aa17-267ca6975798/.default \
  --mode broker \
  --prompt-hint "Test Azure DevOps client broker redirect" \
  --output none \
  --timeout 1 \
  --verbosity debug
```

AzureAuth 0.9.6 uses the macOS broker redirect URI `msauth.com.msauth.unsignedapp://auth`. That redirect URI needs to be added to the app registration for client `872cd9fa-d31f-45e0-9eab-6e460a02d1f1` before this PR can be validated end to end.

## Validation

- `yarn workspace azureauth test`
- `yarn prettier --check packages/node-azureauth/README.md packages/ado-npm-auth/README.md packages/yarn-plugin-ado-auth/README.md`
- `node packages/node-azureauth/scripts/azureauth.cjs --version` reports `0.9.6.0`
- Web auth control path succeeds for `ado pat --mode web`; broker path is blocked by the app-registration redirect URI issue above.
