### PR TITLE
fix(ado-npm-auth-lib): Fix registry URL validation

### DIFF
--- a/packages/ado-npm-auth-lib/src/npmrc/nugetCredentialProvider.ts
+++ b/packages/ado-npm-auth-lib/src/npmrc/nugetCredentialProvider.ts
@@ -26,14 +26,15 @@ export async function credentialProviderPat(
 }
 
 function toNugetUrl(registry: string): string {
-  if (!registry.endsWith("/npm/registry/")) {
+  // Yarn 4 normalizes registry URLs by stripping the trailing slash before
+  // invoking auth hooks, so accept the URL with or without it.
+  const normalized = registry.endsWith("/") ? registry : registry + "/";
+  if (!normalized.endsWith("/npm/registry/")) {
     throw new Error(
       `Registry URL ${registry} is not a valid Azure Artifacts npm registry URL. Expected it to end with '/npm/registry/'`,
     );
   }
-  return (
-    "https://" + registry.replace("/npm/registry/", "/nuget/v3/index.json")
-  );
+  return normalized.replace("/npm/registry/", "/nuget/v3/index.json");
 }
 
 async function invokeCredentialProvider(


### PR DESCRIPTION
Yarn 4 normalizes registry URLs by stripping the trailing slash before invoking auth hooks (see TokenCache.getRegistryConfiguration in yarn-plugin-ado-auth, which mirrors Yarn's internal behavior). This caused toNugetUrl to reject otherwise-valid feed URLs configured as .../npm/registry/ in .yarnrc.yml.

Additionally, the previous implementation prepended 'https://' to the registry string, which already includes a scheme, producing a malformed 'https://https://...' nuget feed URL. This bug was latent because the endsWith check threw first.

This fix:
- Normalizes the registry URL by appending a trailing slash before the endsWith check, so both forms are accepted.
- Removes the spurious 'https://' prefix; the input already contains the scheme.