### PR TITLE
Fix registry url validation for yarn v4

### DIFF
--- a/change/change-2227fcff-ea28-44d4-a936-04b8bedc60d0.json
+++ b/change/change-2227fcff-ea28-44d4-a936-04b8bedc60d0.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Fix registry url validation for yarn v4",
+      "packageName": "@microsoft/ado-npm-auth-lib",
+      "email": "alwaibel@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/ado-npm-auth-lib/src/npmrc/nugetCredentialProvider.ts
+++ b/packages/ado-npm-auth-lib/src/npmrc/nugetCredentialProvider.ts
@@ -26,14 +26,15 @@ export async function credentialProviderPat(
 }
 
 function toNugetUrl(registry: string): string {
-  if (!registry.endsWith("/npm/registry/")) {
+  // Yarn 4 normalizes registry URLs by stripping the trailing slash before
+  // invoking auth hooks, so accept the URL with or without it.
+  const normalized = registry.endsWith("/") ? registry : registry + "/";
+  if (!normalized.endsWith("/npm/registry/")) {
     throw new Error(
       `Registry URL ${registry} is not a valid Azure Artifacts npm registry URL. Expected it to end with '/npm/registry/'`,
     );
   }
-  return (
-    "https://" + registry.replace("/npm/registry/", "/nuget/v3/index.json")
-  );
+  return normalized.replace("/npm/registry/", "/nuget/v3/index.json");
 }
 
 async function invokeCredentialProvider(

--- a/packages/ado-npm-auth-lib/src/npmrc/nugetCredentialProvider.ts
+++ b/packages/ado-npm-auth-lib/src/npmrc/nugetCredentialProvider.ts
@@ -34,7 +34,14 @@ function toNugetUrl(registry: string): string {
       `Registry URL ${registry} is not a valid Azure Artifacts npm registry URL. Expected it to end with '/npm/registry/'`,
     );
   }
-  return normalized.replace("/npm/registry/", "/nuget/v3/index.json");
+  const nugetPath = normalized.replace(
+    "/npm/registry/",
+    "/nuget/v3/index.json",
+  );
+  // Tolerate scheme-less inputs (e.g. older callers) by prepending https://
+  // when no scheme is present. Yarn 4 always supplies a scheme, but the
+  // function signature accepts any string.
+  return /^[a-z]+:\/\//i.test(nugetPath) ? nugetPath : "https://" + nugetPath;
 }
 
 async function invokeCredentialProvider(

--- a/packages/yarn-plugin-ado-auth/src/tokenCache.ts
+++ b/packages/yarn-plugin-ado-auth/src/tokenCache.ts
@@ -58,6 +58,15 @@ export class TokenCache {
    */
   private async fetchToken(registry: string, ident?: Ident): Promise<string> {
     const configuration = this.configuration;
+    // Resolved within the StreamReport callback below. We do *not* write
+    // directly to `this.cache[registry]` from inside the callback: the
+    // `via configuration` path is fully synchronous, which would mutate the
+    // cache before getToken's `??=` assigns the in-flight promise — the
+    // assignment would then overwrite the string with the promise, and this
+    // function would end up returning its own promise (causing
+    // "Chaining cycle detected for promise"). Cache management is left to
+    // getToken's `??=` so there is exactly one writer per registry.
+    let token: string | undefined;
     await StreamReport.start(
       { configuration, stdout: process.stdout },
       async (report) => {
@@ -70,7 +79,7 @@ export class TokenCache {
         const authConfig = this.getAuthConfiguration(registry, ident);
         const tokenFromYarnrc = getConfigString(authConfig, "npmAuthToken");
         if (tokenFromYarnrc) {
-          this.cache[registry] = tokenFromYarnrc;
+          token = tokenFromYarnrc;
           report.reportInfo(
             null,
             `Authenticated to: ${prettyRegistry} (via configuration)`,
@@ -85,13 +94,12 @@ export class TokenCache {
           );
         }
 
-        const pat = await generateNpmrcPat(
+        token = await generateNpmrcPat(
           organization,
           registry,
           false,
           this.azureAuthPath,
         );
-        this.cache[registry] = pat;
         report.reportInfo(
           null,
           `Authenticated to: ${prettyRegistry} (via ADO CLI)`,
@@ -99,11 +107,10 @@ export class TokenCache {
       },
     );
 
-    const pat = this.cache[registry];
-    if (pat == null) {
+    if (token == null) {
       throw new Error(`Failed to authenticate to: ${registry}`);
     }
-    return pat;
+    return token;
   }
 
   /**

--- a/packages/yarn-plugin-ado-auth/src/tokenCache.ts
+++ b/packages/yarn-plugin-ado-auth/src/tokenCache.ts
@@ -58,15 +58,8 @@ export class TokenCache {
    */
   private async fetchToken(registry: string, ident?: Ident): Promise<string> {
     const configuration = this.configuration;
-    // Resolved within the StreamReport callback below. We do *not* write
-    // directly to `this.cache[registry]` from inside the callback: the
-    // `via configuration` path is fully synchronous, which would mutate the
-    // cache before getToken's `??=` assigns the in-flight promise — the
-    // assignment would then overwrite the string with the promise, and this
-    // function would end up returning its own promise (causing
-    // "Chaining cycle detected for promise"). Cache management is left to
-    // getToken's `??=` so there is exactly one writer per registry.
-    let token: string | undefined;
+    let token: string | null = null;
+
     await StreamReport.start(
       { configuration, stdout: process.stdout },
       async (report) => {
@@ -80,6 +73,7 @@ export class TokenCache {
         const tokenFromYarnrc = getConfigString(authConfig, "npmAuthToken");
         if (tokenFromYarnrc) {
           token = tokenFromYarnrc;
+          this.cache[registry] = tokenFromYarnrc;
           report.reportInfo(
             null,
             `Authenticated to: ${prettyRegistry} (via configuration)`,
@@ -94,12 +88,14 @@ export class TokenCache {
           );
         }
 
-        token = await generateNpmrcPat(
+        const pat = await generateNpmrcPat(
           organization,
           registry,
           false,
           this.azureAuthPath,
         );
+        token = pat;
+        this.cache[registry] = pat;
         report.reportInfo(
           null,
           `Authenticated to: ${prettyRegistry} (via ADO CLI)`,


### PR DESCRIPTION
Yarn v4 strips trailing slashes from registry URLs. It also requires URL scheme (aka https://) which prior versions did not. This PR fixes validation for these cases while maintaining backwards compatibility for older yarn versions.