### PR TITLE
Fix publish.yml failure.

### DIFF
--- a/.ado/prep-node.yml
+++ b/.ado/prep-node.yml
@@ -20,3 +20,7 @@ steps:
   - script: |
       npm install -g yarn
     displayName: "Setup yarn"
+
+  - bash: |
+      cp publish.yarnrc.yml .yarnrc.yml
+    displayName: "Configure .yarnrc.yml to use CFS"

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -114,10 +114,6 @@ extends:
               parameters:
                 nodeVersion: 24.x
 
-            - bash: |
-                cp publish.yarnrc.yml .yarnrc.yml
-              displayName: "Configure .yarnrc.yml to use CFS"
-
             - script: yarn install --immutable
               displayName: Yarn Install (Install package dependencies)
 

--- a/publish.yarnrc.yml
+++ b/publish.yarnrc.yml
@@ -22,6 +22,6 @@ plugins:
 
 yarnPath: .yarn/releases/yarn-4.17.0.cjs
 
-npmRegistryServer: https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/
+npmRegistryServer: https://pkgs.dev.azure.com/office/_packaging/Office/npm/registry/
 npmAlwaysAuth: true
 npmrcAuthEnabled: true

--- a/publish.yarnrc.yml
+++ b/publish.yarnrc.yml
@@ -18,7 +18,7 @@ npmMinimalAgeGate: 0
 plugins:
   - checksum: 471ba8134605c19541845aab20958d5dd51f00bb2dc53d54da5f2f2d61fbf5f93dbf845481e5fc34e9602409bfab6600415f0c17fa4e18cdfedbb07c50565fac
     path: .yarn/plugins/@yarnpkg/plugin-npmrc.cjs
-    spec: "https://raw.githubusercontent.com/ecraig12345/yarn-plugins/npmrc_v0.4.1/plugins/npmrc/dist/plugin.js"
+    spec: "https://raw.githubusercontent.com/microsoft/beachball/yarn-plugin-npmrc_v0.5.0/yarn-plugins/npmrc/dist/plugin.js"
 
 yarnPath: .yarn/releases/yarn-4.17.0.cjs
 


### PR DESCRIPTION
Attempts to fix publish.yml failure by correcting registry URL mismatch between publish.yarnrc.yml and publish.npmrc.

Also updates the URL for yarn-plugin-npmrc to point beachball repo.