### PR TITLE
Remove global yarn install step from publish.yml.

### DIFF
--- a/.ado/prep-node.yml
+++ b/.ado/prep-node.yml
@@ -17,10 +17,6 @@ steps:
     inputs:
       workingFile: '.npmrc'
 
-  - script: |
-      npm install -g yarn
-    displayName: "Setup yarn"
-
   - bash: |
       cp publish.yarnrc.yml .yarnrc.yml
     displayName: "Configure .yarnrc.yml to use CFS"


### PR DESCRIPTION
Remove global yarn install step from publish.yml since this step is no longer needed after we switched to corepack and yarn berry.