### PR TITLE
Fix yarn-plugin-ado-auth import URL in readme

### DIFF
--- a/beachball.config.js
+++ b/beachball.config.js
@@ -1,8 +1,9 @@
 // @ts-check
 /** @type {import("beachball").BeachballConfig} */
 const config = {
-  changehint: 'Run "yarn change" to generate a change file',
   branch: "main",
+  changehint: 'Run "yarn change" to generate a change file',
+  commit: false,
   // The current publishing setup skips the step that creates git tags, so make it explicit that they're not created
   gitTags: false,
   groupChanges: true,

--- a/change/change-1b6cd6e6-257e-46a0-8c23-4489337deac8.json
+++ b/change/change-1b6cd6e6-257e-46a0-8c23-4489337deac8.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Fix import URL in readme",
+      "packageName": "@microsoft/yarn-plugin-ado-auth",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/yarn-plugin-ado-auth/README.md
+++ b/packages/yarn-plugin-ado-auth/README.md
@@ -19,7 +19,7 @@ This approach provides a frictionless developer experience - you never need to m
 Add the plugin to your Yarn project:
 
 ```bash
-yarn plugin import https://github.com/microsoft/ado-npm-auth/releases/download/latest/yarn-plugin-ado-auth.cjs
+yarn plugin import https://unpkg.com/@microsoft/yarn-plugin-ado-auth/dist/yarn-plugin-ado-auth.cjs
 ```
 
 Or install from a local build:
@@ -34,7 +34,7 @@ The plugin supports two configuration options in your `.yarnrc.yml` file:
 
 ### `adoNpmAuthFeedPrefix`
 
-**Type:** `string`  
+**Type:** `string`
 **Default:** `"https://pkgs.dev.azure.com/"`
 
 The URL prefix used to identify Azure DevOps npm feeds. The plugin only attempts authentication for registries that start with this prefix.
@@ -45,7 +45,7 @@ adoNpmAuthFeedPrefix: "https://pkgs.dev.azure.com/"
 
 ### `adoNpmAuthToolPath`
 
-**Type:** `string` (optional)  
+**Type:** `string` (optional)
 **Default:** `null` (uses `azureauth` from PATH)
 
 The absolute path to the `azureauth` CLI tool. If not specified, the plugin will search for `azureauth` in your system PATH. Note that yarn has a pattern where environment variables starting with YARN\_ will override .yarnrc.yml settings. So setting YARN_ADO_NPM_AUTH_TOOL_PATH can be used to override this value on the fly.


### PR DESCRIPTION
The URL currently in the plugin readme doesn't exist.

The most common practice for yarn plugins appears to be to check in the generated output ([example](https://github.com/microsoft/beachball/tree/main/yarn-plugins/npmrc/dist)), but since that's not how this repo is currently set up, it's necessary to point to some other link. https://unpkg.com/@microsoft/yarn-plugin-ado-auth/dist/yarn-plugin-ado-auth.cjs is an easy option that doesn't require any extra config.